### PR TITLE
Allow preloading of data looked up during fastboot rendering.

### DIFF
--- a/addon/instance-initializers/preload-data.js
+++ b/addon/instance-initializers/preload-data.js
@@ -1,0 +1,30 @@
+import Ember from 'ember';
+
+const { $, keys } = Ember;
+
+export default {
+  initialize(instance) {
+    if (!$) {
+      return;
+    }
+
+    const rawDump = Ember.$('meta[name="preload-data"]').attr('content');
+
+    if (!rawDump) {
+      return;
+    }
+
+    const data = JSON.parse(decodeURIComponent(rawDump));
+    const storeNames = keys(data);
+
+    for (let index = 0, length = storeNames.length; index < length; index++) {
+      const storeFullName = storeNames[index];
+      const store = instance.container.lookup(storeFullName);
+      const storeData = data[storeFullName];
+
+      if (store && store.populateCache) {
+        store.populateCache(storeData);
+      }
+    }
+  }
+};

--- a/addon/store.js
+++ b/addon/store.js
@@ -1,0 +1,48 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+
+const keys = Ember.keys;
+const create = Ember.create;
+export const knownStores = [];
+
+export default DS.Store.extend({
+  init() {
+    this._super(...arguments);
+    knownStores.push(this._debugContainerKey);
+  },
+
+  populateCache(dump) {
+    const types = keys(dump);
+
+    for (let index = 0, length = types.length; index < length; index++) {
+      const typeKey = types[index];
+      const records = dump[typeKey];
+
+      this.pushMany(typeKey, records);
+    }
+  },
+
+  serializeCache() {
+    let results = create(null);
+
+    const types = keys(this.typeMaps);
+
+    for (let index = 0, length = types.length; index < length; index++) {
+      const typeId = types[index];
+      const typeKey = this.typeMaps[typeId].type.typeKey;
+      const records = this.typeMaps[typeId].records;
+      const recordCount = records.length;
+
+      results[typeKey] = [];
+
+      for (let currentRecord = 0; currentRecord < recordCount; currentRecord++) {
+        const record = records[currentRecord];
+        const serializedRecord = record.toJSON({ includeId: true });
+
+        results[typeKey].push(serializedRecord);
+      }
+    }
+
+    return results;
+  }
+});

--- a/addon/utils/serialize-stores.js
+++ b/addon/utils/serialize-stores.js
@@ -1,0 +1,19 @@
+import Ember from 'ember';
+import { knownStores } from '../store';
+
+const { create } = Ember;
+
+export default function(container) {
+  const results = create(null);
+
+  for (let index = 0, length = knownStores.length; index < length; index++) {
+    const storeFullName = knownStores[index];
+    const store = container.lookup(storeFullName);
+
+    if (store && store.serializeCache) {
+      results[storeFullName] = store.serializeCache();
+    }
+  }
+
+  return results;
+}

--- a/app/initializers/fastboot.js
+++ b/app/initializers/fastboot.js
@@ -1,5 +1,7 @@
 /*globals SimpleDOM, Ember, FastBoot, URL*/
 
+import serializeStores from 'ember-cli-fastboot/utils/serialize-stores';
+
 export default {
   name: "fast-boot",
 
@@ -35,7 +37,9 @@ export default {
         return App.visit(url).then(function(instance) {
           var view = instance.view;
           var title = view.renderer._dom.document.title;
+          var data = serializeStores(view.container);
           var element;
+
 
           Ember.run(function() {
             element = view.renderToElement();
@@ -47,7 +51,8 @@ export default {
 
           return {
             body: serializer.serialize(element),
-            title: title
+            title: title,
+            data: data
           };
         });
       });

--- a/app/instance-initializers/preload-data.js
+++ b/app/instance-initializers/preload-data.js
@@ -1,0 +1,3 @@
+import initializer from 'ember-cli-fastboot/instance-initializers/preload-data';
+
+export default initializer;

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ module.exports = {
     }
 
     if (type === 'head') {
-      return "<!-- EMBER_CLI_FASTBOOT_TITLE -->";
+      return "<!-- EMBER_CLI_FASTBOOT_TITLE -->\n" +
+        "<!-- EMBER_CLI_FASTBOOT_DATA -->";
     }
 
     if (type === 'vendor-prefix') {

--- a/lib/models/server.js
+++ b/lib/models/server.js
@@ -21,11 +21,16 @@ FastBootServer.prototype.log = function(statusCode, message) {
   this.ui.writeLine(chalk[color](statusCode) + " " + message);
 };
 
-FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
-  var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", body);
+FastBootServer.prototype.insertIntoIndexHTML = function(result) {
+  var html = this.html.replace("<!-- EMBER_CLI_FASTBOOT_BODY -->", result.body);
 
-  if (title) {
-    html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + title + "</title>");
+  if (result.title) {
+    html = html.replace("<!-- EMBER_CLI_FASTBOOT_TITLE -->", "<title>" + result.title + "</title>");
+  }
+
+  if (result.data) {
+    var encodedData = encodeURIComponent(JSON.stringify(result.data));
+    html = html.replace("<!-- EMBER_CLI_FASTBOOT_DATA -->", "<meta name='preload-data' content='" + encodedData + "'>");
   }
 
   return html;
@@ -33,7 +38,7 @@ FastBootServer.prototype.insertIntoIndexHTML = function(title, body) {
 
 FastBootServer.prototype.handleSuccess = function(res, path, result) {
   this.log(200, 'OK ' + path);
-  res.send(this.insertIntoIndexHTML(result.title, result.body));
+  res.send(this.insertIntoIndexHTML(result));
 };
 
 FastBootServer.prototype.handleFailure = function(res, path, error) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "chai": "^2.2.0",
     "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
     "ember-cli-content-security-policy": "0.3.0",
     "ember-cli-dependency-checker": "0.0.8",
     "ember-cli-htmlbars": "0.7.4",
@@ -42,13 +41,14 @@
     "configPath": "tests/dummy/config"
   },
   "dependencies": {
-    "contextify": "^0.1.11",
-    "najax": "^0.1.5",
-    "rsvp": "^3.0.16",
-    "simple-dom": "0.2.1",
     "chalk": "^0.5.1",
+    "contextify": "^0.1.11",
+    "debug": "^2.1.0",
+    "ember-cli-babel": "^5.0.0",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "debug": "^2.1.0"
+    "najax": "^0.1.5",
+    "rsvp": "^3.0.16",
+    "simple-dom": "0.2.1"
   }
 }


### PR DESCRIPTION
Using the provided store will seed the store in the booted application with the data that was fetched during the Fastboot rendering process.

---

In your app you need to use `ember-cli-fastboot/store` as your stores base class. Often this just means importing and reexporting in your `app/store.js` file:

```javascript
// app/store.js
import Store from 'ember-cli-fastboot/store';

export default Store;
```