### PR TITLE
Allow ember-data to work when `host` is not defined

### DIFF
--- a/app/initializers/fastboot/ajax.js
+++ b/app/initializers/fastboot/ajax.js
@@ -1,6 +1,19 @@
 /* globals najax */
+import Ember from 'ember';
+
+const { get } = Ember;
 
 var nodeAjax = function(options) {
+  let httpRegex = /^https?:\/\//
+
+  if (!httpRegex.test(options.url)) {
+    try {
+      options.url = get(this, 'fastboot.host') + options.url
+    } catch (fbError) {
+      throw new Error('You are using Ember Data with no host defined in your adapter. This will attempt to use the host of the FastBoot request, which is not configured for the current host of this request. Please set the hostWhitelist property for in your environment.js. FastBoot Error: ' + fbError.message);
+    }
+  }
+
   najax(options);
 };
 
@@ -10,5 +23,6 @@ export default {
   initialize: function(application) {
     application.register('ajax:node', nodeAjax, { instantiate: false });
     application.inject('adapter', '_ajaxRequest', 'ajax:node');
+    application.inject('adapter', 'fastboot', 'service:fastboot');
   }
 };


### PR DESCRIPTION
This uses the headers/request fron express to figure out where to make
the najax request to.

This is in lieu of a proper jQuery AJAX transport