### PR TITLE
consume as a broccoli tree instead of re-creating EmberApp

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,10 +79,9 @@ module.exports = {
   postprocessTree: function(type, tree) {
     if (type === 'all') {
       var fastbootTree = this.buildFastBootTree();
-      var configTree = this.buildConfigTree(fastbootTree);
 
       // Merge the package.json with the existing tree
-      return mergeTrees([configTree, tree, fastbootTree], {overwrite: true});
+      return mergeTrees([tree, fastbootTree], {overwrite: true});
     }
 
     return tree;

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = {
       var configTree = this.buildConfigTree(fastbootTree);
 
       // Merge the package.json with the existing tree
-      return mergeTrees([configTree, tree, fastbootTree]);
+      return mergeTrees([configTree, tree, fastbootTree], {overwrite: true});
     }
 
     return tree;

--- a/index.js
+++ b/index.js
@@ -89,6 +89,7 @@ module.exports = {
 
   buildFastBootTree: function() {
     var fastbootBuild = new FastBootBuild({
+      ui: this.ui,
       project: this.project,
       app: this.app,
       parent: this.parent

--- a/index.js
+++ b/index.js
@@ -90,6 +90,7 @@ module.exports = {
   buildFastBootTree: function() {
     var fastbootBuild = new FastBootBuild({
       ui: this.ui,
+      assetMapPath: this.assetMapPath,
       project: this.project,
       app: this.app,
       parent: this.parent

--- a/index.js
+++ b/index.js
@@ -87,20 +87,6 @@ module.exports = {
     return tree;
   },
 
-  buildConfigTree: function(tree) {
-    var env = this.app.env;
-
-    // Create a new Broccoli tree that writes the FastBoot app's
-    // `package.json`.
-    return new FastBootConfig(tree, {
-      project: this.project,
-      name: this.app.name,
-      assetMapPath: this.assetMapPath,
-      ui: this.ui,
-      fastbootAppConfig: this.project.config(env).fastboot
-    });
-  },
-
   buildFastBootTree: function() {
     var fastbootBuild = new FastBootBuild({
       project: this.project,

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -18,6 +18,7 @@ function EmptyTree(inputNodes, options) {
 EmptyTree.prototype.build = function() { };
 
 function FastBootBuild(options) {
+  this.ui = options.ui;
   this.options = options;
   this.project = options.project;
   this.app = options.app;

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -18,6 +18,7 @@ function EmptyTree(inputNodes, options) {
 EmptyTree.prototype.build = function() { };
 
 function FastBootBuild(options) {
+  this.assetMapPath = this.assetMapPath;
   this.ui = options.ui;
   this.options = options;
   this.project = options.project;

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -58,7 +58,7 @@ FastBootBuild.prototype.toTree = function() {
   var fastbootTree = new Funnel(emberApp, {
     srcDir: 'assets',
     destDir: 'fastboot',
-    include: ['**/*.js']
+    include: ['**/*.js', '**/*.json']
   });
 
   delete env.EMBER_CLI_FASTBOOT;

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -21,6 +21,7 @@ function FastBootBuild(options) {
   this.options = options;
   this.project = options.project;
   this.app = options.app;
+  this.name = this.app.name;
   this.parent = options.parent;
 }
 
@@ -55,16 +56,23 @@ FastBootBuild.prototype.toTree = function() {
 
   // Because this will be merged with the browser build, move the FastBoot
   // build's assets to the fastboot directory.
+
   var fastbootTree = new Funnel(emberApp, {
-    srcDir: 'assets',
-    destDir: 'fastboot',
-    include: ['**/*.js', '**/*.json']
+    srcDir: '/',
+    include: ['assets/**/*.js', '**/*.json']
   });
 
-  delete env.EMBER_CLI_FASTBOOT;
-  delete this.app.options.__is_building_fastboot__;
+  var stew = require('broccoli-stew');
 
-  return this.rewriteAssets(fastbootTree);
+  fastbootTree = stew.mv(fastbootTree, 'assets/assetMap.json', 'fastbootAssetMap.json');
+  fastbootTree = stew.mv(fastbootTree, 'assets/*.js', 'fastboot/');
+
+  delete env.EMBER_CLI_FASTBOOT;
+
+  var configTree = this.buildConfigTree(fastbootTree);
+  var merge = require('broccoli-merge-trees');
+
+  return merge([fastbootTree, configTree], {overwrite: true});
 };
 
 /**
@@ -74,28 +82,48 @@ FastBootBuild.prototype.toTree = function() {
  */
 FastBootBuild.prototype.appOptions = function() {
   return {
+    project: this.buildFastBootProject(),
     autoRun: false,
-    __is_building_fastboot__: true
+    __is_building_fastboot__: true,
   };
 };
 
-/**
- * Because the FastBoot addon always runs after broccoli-asset-rev,
- * we have to manually apply it to our tree to get asset rewriting
- * functionality.
- */
-FastBootBuild.prototype.rewriteAssets = function(tree) {
-  var addons = this.parent.addons;
+FastBootBuild.prototype.buildConfigTree = function(tree) {
+  var FastBootConfig = require('./fastboot-config');
+  var env = this.app.env;
 
-  var broccoliAssetRev = find(addons, function(addon) {
-    return addon.name === 'broccoli-asset-rev';
+  // Create a new Broccoli tree that writes the FastBoot app's
+  // `package.json`.
+  return new FastBootConfig(tree, {
+    project: this.project,
+    name: this.app.name,
+    assetMapPath: this.assetMapPath,
+    ui: this.ui,
+    fastbootAppConfig: this.project.config(env).fastboot
   });
+};
 
-  if (!broccoliAssetRev) { return tree; }
+/**
+ * Because the config information is not read until build time, the
+ * EMBER_CLI_FASTBOOT environment variable is not set when the FastBoot
+ * build actually happens.
+ *
+ * To get around this, we give the FastBoot tree a reference to a project
+ * that is modified to always return a FastBoot-compatible config.
+ */
+FastBootBuild.prototype.buildFastBootProject = function() {
+  var project = Object.create(this.project);
 
-  broccoliAssetRev.options.generateAssetMap = true;
-  broccoliAssetRev.options.assetMapPath = 'fastbootAssetMap.json';
-  return broccoliAssetRev.postprocessTree('all', tree);
+  project.config = function() {
+    var config = Object.getPrototypeOf(this).config.apply(this, arguments);
+
+    config.APP = config.APP || {};
+    config.APP.autoboot = false;
+
+    return config;
+  };
+
+  return project;
 };
 
 module.exports = FastBootBuild;

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -1,6 +1,21 @@
 var Funnel    = require('broccoli-funnel');
 var cloneDeep = require('lodash.clonedeep');
 var find      = require('lodash.find');
+var Plugin = require('broccoli-plugin');
+
+// The EmptyTree just returns a broccoli tree with no files
+// into it so broccoli doesn't try to read a tree from
+// undefined.
+EmptyTree.prototype = Object.create(Plugin.prototype);
+EmptyTree.prototype.constructor = EmptyTree;
+function EmptyTree(inputNodes, options) {
+  options = options || {};
+  this.persistentOutput = options.persistentOutput = true;
+  Plugin.call(this, inputNodes, options);
+  this.options = options;
+}
+
+EmptyTree.prototype.build = function() { };
 
 function FastBootBuild(options) {
   this.options = options;
@@ -17,6 +32,12 @@ function FastBootBuild(options) {
 FastBootBuild.prototype.toTree = function() {
   var env = process.env;
 
+  // This method will be called again when we create the new EmberApp below.
+  // This is to prevent infinite recursion.
+  if (this.app.options.__is_building_fastboot__) {
+    return new EmptyTree([]);
+  }
+
   // Set the EMBER_CLI_FASTBOOT environment variable. This serves as a hint
   // for other addons that they should build their trees configured for the
   // FastBoot build.
@@ -27,21 +48,20 @@ FastBootBuild.prototype.toTree = function() {
 
   var options = this.appOptions();
 
-  var EmberApp = this.app.constructor;
-  var emberApp = new EmberApp(options);
-
-  // Ask the Ember app for the Broccoli tree representing its JavaScript
-  // assets.
-  var fastbootTree = emberApp.javascript();
+  // re-require with env.EMBER_CLI_FASTBOOT on
+  var path = require('path');
+  var emberBuildFile = path.join(this.project.root, 'ember-cli-build.js');
+  var emberApp = require(emberBuildFile)(options);
 
   // Because this will be merged with the browser build, move the FastBoot
   // build's assets to the fastboot directory.
-  fastbootTree = new Funnel(fastbootTree, {
+  var fastbootTree = new Funnel(emberApp, {
     srcDir: 'assets',
     destDir: 'fastboot'
   });
 
   delete env.EMBER_CLI_FASTBOOT;
+  delete this.app.options.__is_building_fastboot__;
 
   return this.rewriteAssets(fastbootTree);
 };
@@ -56,6 +76,7 @@ FastBootBuild.prototype.appOptions = function() {
 
   options.autoRun = false;
   options.project = this.buildFastBootProject();
+  options.__is_building_fastboot__ = true;
 
   return options;
 };

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -57,7 +57,8 @@ FastBootBuild.prototype.toTree = function() {
   // build's assets to the fastboot directory.
   var fastbootTree = new Funnel(emberApp, {
     srcDir: 'assets',
-    destDir: 'fastboot'
+    destDir: 'fastboot',
+    include: ['**/*.js']
   });
 
   delete env.EMBER_CLI_FASTBOOT;
@@ -72,36 +73,10 @@ FastBootBuild.prototype.toTree = function() {
  * FastBoot compatible.
  */
 FastBootBuild.prototype.appOptions = function() {
-  var options = cloneDeep(this.app.options);
-
-  options.autoRun = false;
-  options.project = this.buildFastBootProject();
-  options.__is_building_fastboot__ = true;
-
-  return options;
-};
-
-/**
- * Because the config information is not read until build time, the
- * EMBER_CLI_FASTBOOT environment variable is not set when the FastBoot
- * build actually happens.
- *
- * To get around this, we give the FastBoot tree a reference to a project
- * that is modified to always return a FastBoot-compatible config.
- */
-FastBootBuild.prototype.buildFastBootProject = function() {
-  var project = Object.create(this.project);
-
-  project.config = function() {
-    var config = Object.getPrototypeOf(this).config.apply(this, arguments);
-
-    config.APP = config.APP || {};
-    config.APP.autoboot = false;
-
-    return config;
+  return {
+    autoRun: false,
+    __is_building_fastboot__: true
   };
-
-  return project;
 };
 
 /**

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -2,6 +2,7 @@ var Funnel    = require('broccoli-funnel');
 var cloneDeep = require('lodash.clonedeep');
 var find      = require('lodash.find');
 var Plugin = require('broccoli-plugin');
+var defaults = require('lodash.defaults');
 
 // The EmptyTree just returns a broccoli tree with no files
 // into it so broccoli doesn't try to read a tree from
@@ -78,7 +79,7 @@ FastBootBuild.prototype.toTree = function() {
   });
 
   fastbootTree = stew.mv(fastbootTree, this.assetMapPath, '/fastbootAssetMap.json');
-  fastbootTree = stew.mv(fastbootTree, 'assets/*.js', 'fastboot/');
+  fastbootTree = stew.mv(fastbootTree, 'assets/*.*', 'fastboot/');
 
   delete env.EMBER_CLI_FASTBOOT;
 
@@ -94,11 +95,12 @@ FastBootBuild.prototype.toTree = function() {
  * FastBoot compatible.
  */
 FastBootBuild.prototype.appOptions = function() {
-  return {
-    project: this.buildFastBootProject(),
+  var options = cloneDeep(this.app.options);
+  return defaults({
     autoRun: false,
+    project: this.buildFastBootProject(),
     __is_building_fastboot__: true,
-  };
+  });
 };
 
 FastBootBuild.prototype.buildConfigTree = function(tree) {

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -18,11 +18,21 @@ function EmptyTree(inputNodes, options) {
 EmptyTree.prototype.build = function() { };
 
 function FastBootBuild(options) {
-  this.assetMapPath = this.assetMapPath;
+  this.assetMapPath = options.assetMapPath || 'assets/assetMap.json';
+  this.project = options.project;
+  var assetRev = this.project.addons.filter(function(addon) {
+    return addon.name === 'broccoli-asset-rev';
+  })[0];
+
+  if (assetRev) {
+    if (assetRev.options && assetRev.options.assetMapPath) {
+      this.assetMapPath = assetRev.options.assetMapPath;
+    }
+  }
+
+  this.assetMapPath = this.assetMapPath || 'assets/assetMap.json';
   this.ui = options.ui;
   this.options = options;
-  this.project = options.project;
-  this.project.config = this.buildFastBootProject().bind(this.project);
   this.app = options.app;
   this.name = this.app.name;
   this.parent = options.parent;
@@ -62,13 +72,13 @@ FastBootBuild.prototype.toTree = function() {
   //
   var stew = require('broccoli-stew');
 
-  var fastbootTree = new Funnel(stew.log(emberApp, {output: 'tree'}), {
+  var fastbootTree = new Funnel(emberApp, {
     srcDir: '/',
     include: ['assets/**/*.js', '**/*.json']
   });
 
-  fastbootTree = stew.mv(stew.log(fastbootTree, {output: 'tree'}), 'assets/assetMap.json', '/fastbootAssetMap.json');
-  fastbootTree = stew.mv(stew.log(fastbootTree, {output: 'tree'}), 'assets/*.js', 'fastboot/');
+  fastbootTree = stew.mv(fastbootTree, this.assetMapPath, '/fastbootAssetMap.json');
+  fastbootTree = stew.mv(fastbootTree, 'assets/*.js', 'fastboot/');
 
   delete env.EMBER_CLI_FASTBOOT;
 
@@ -85,6 +95,7 @@ FastBootBuild.prototype.toTree = function() {
  */
 FastBootBuild.prototype.appOptions = function() {
   return {
+    project: this.buildFastBootProject(),
     autoRun: false,
     __is_building_fastboot__: true,
   };
@@ -114,7 +125,10 @@ FastBootBuild.prototype.buildConfigTree = function(tree) {
  * that is modified to always return a FastBoot-compatible config.
  */
 FastBootBuild.prototype.buildFastBootProject = function() {
-  return function config () {
+  var Project = require('ember-cli/lib/models/project');
+  var oldProject = this.project;
+  var project = new Project(oldProject.root, oldProject.pkg, oldProject.ui, oldProject.cli);
+  project.config = function config() {
     var config = Object.getPrototypeOf(this).config.apply(this, arguments);
 
     config.APP = config.APP || {};
@@ -122,6 +136,8 @@ FastBootBuild.prototype.buildFastBootProject = function() {
 
     return config;
   };
+
+  return project;
 };
 
 module.exports = FastBootBuild;

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -22,6 +22,7 @@ function FastBootBuild(options) {
   this.ui = options.ui;
   this.options = options;
   this.project = options.project;
+  this.project.config = this.buildFastBootProject().bind(this.project);
   this.app = options.app;
   this.name = this.app.name;
   this.parent = options.parent;
@@ -58,16 +59,16 @@ FastBootBuild.prototype.toTree = function() {
 
   // Because this will be merged with the browser build, move the FastBoot
   // build's assets to the fastboot directory.
+  //
+  var stew = require('broccoli-stew');
 
-  var fastbootTree = new Funnel(emberApp, {
+  var fastbootTree = new Funnel(stew.log(emberApp, {output: 'tree'}), {
     srcDir: '/',
     include: ['assets/**/*.js', '**/*.json']
   });
 
-  var stew = require('broccoli-stew');
-
-  fastbootTree = stew.mv(fastbootTree, 'assets/assetMap.json', 'fastbootAssetMap.json');
-  fastbootTree = stew.mv(fastbootTree, 'assets/*.js', 'fastboot/');
+  fastbootTree = stew.mv(stew.log(fastbootTree, {output: 'tree'}), 'assets/assetMap.json', '/fastbootAssetMap.json');
+  fastbootTree = stew.mv(stew.log(fastbootTree, {output: 'tree'}), 'assets/*.js', 'fastboot/');
 
   delete env.EMBER_CLI_FASTBOOT;
 
@@ -84,7 +85,6 @@ FastBootBuild.prototype.toTree = function() {
  */
 FastBootBuild.prototype.appOptions = function() {
   return {
-    project: this.buildFastBootProject(),
     autoRun: false,
     __is_building_fastboot__: true,
   };
@@ -114,9 +114,7 @@ FastBootBuild.prototype.buildConfigTree = function(tree) {
  * that is modified to always return a FastBoot-compatible config.
  */
 FastBootBuild.prototype.buildFastBootProject = function() {
-  var project = Object.create(this.project);
-
-  project.config = function() {
+  return function config () {
     var config = Object.getPrototypeOf(this).config.apply(this, arguments);
 
     config.APP = config.APP || {};
@@ -124,8 +122,6 @@ FastBootBuild.prototype.buildFastBootProject = function() {
 
     return config;
   };
-
-  return project;
 };
 
 module.exports = FastBootBuild;

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -3,6 +3,7 @@ var fmt    = require('util').format;
 var uniq   = require('lodash.uniq');
 var path   = require('path');
 var Plugin = require('broccoli-plugin');
+var defaults = require('lodash.defaults');
 
 function FastBootConfig(inputNode, options) {
   Plugin.call(this, [inputNode], {
@@ -82,7 +83,6 @@ FastBootConfig.prototype.readAssetManifest = function() {
 
   try {
     var assetMap = JSON.parse(fs.readFileSync(assetMapPath));
-    fs.unlinkSync(assetMapPath);
     return assetMap;
   } catch (e) {
     // No asset map was found, proceed as usual
@@ -103,13 +103,19 @@ FastBootConfig.prototype.buildManifest = function() {
   var rewrittenAssets = this.readAssetManifest();
 
   if (rewrittenAssets) {
+    var assets = {};
+
+    // Because the assetMap was written before the files in the
+    // `asset` folder were moved to the `fastboot` folder,
+    // we have to rewrite them here.
+    for (var key in rewrittenAssets.assets) {
+      var rewrittenKey = assetToFastboot(key);
+      assets[rewrittenKey] = assetToFastboot(rewrittenAssets.assets[key]);
+    }
+
     ['appFile', 'vendorFile'].forEach(function(file) {
-      // The file generated for the assetMap.json will point
-      // to assets. After the build, we move it to the
-      // `fastboot` directory so we need to update it accordingly.
-      var asset = rewrittenAssets.assets[manifest[file]];
-      var fileName = path.basename(asset);
-      manifest[file] = path.join('fastboot', fileName);
+      // Update package.json with the fingerprinted file.
+      manifest[file] = assets[manifest[file]];
     });
   }
 
@@ -167,3 +173,12 @@ function getDependencyVersion(pkg, dep) {
 }
 
 module.exports = FastBootConfig;
+
+function assetToFastboot(key) {
+  var parts = key.split('/');
+  var dir = parts[0];
+  if (dir === 'assets') {
+    parts[0] = 'fastboot';
+  }
+  return parts.join('/');
+}

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -90,6 +90,7 @@ FastBootConfig.prototype.readAssetManifest = function() {
 };
 
 FastBootConfig.prototype.buildManifest = function() {
+  var path = require('path');
   var appFile = 'fastboot/' + this.name + '.js';
   var vendorFile = 'fastboot/vendor.js';
 
@@ -103,7 +104,12 @@ FastBootConfig.prototype.buildManifest = function() {
 
   if (rewrittenAssets) {
     ['appFile', 'vendorFile'].forEach(function(file) {
-      manifest[file] = rewrittenAssets.assets[manifest[file]];
+      // The file generated for the assetMap.json will point
+      // to assets. After the build, we move it to the
+      // `fastboot` directory so we need to update it accordingly.
+      var asset = rewrittenAssets.assets[manifest[file]];
+      var fileName = path.basename(asset);
+      manifest[file] = path.join('fastboot', fileName);
     });
   }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "glob": "^7.0.0",
     "mocha": "^2.2.4",
     "request": "^2.55.0",
-    "rimraf": "^2.5.2",
     "symlink-or-copy": "^1.0.1",
     "temp": "^0.8.3",
     "walk-sync": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai-fs": "peterkc/chai-fs#31deec5232297e2887a2ffb39b9081364c8e78e1",
     "chalk": "^1.1.1",
     "cpr": "^1.0.0",
-    "ember-cli": "1.13.15",
+    "ember-cli": "^2.4.0",
     "ember-cli-addon-tests": "^0.2.4",
     "ember-cli-app-version": "0.5.0",
     "ember-cli-content-security-policy": "0.4.0",
@@ -44,7 +44,7 @@
     "glob": "^7.0.0",
     "mocha": "^2.2.4",
     "request": "^2.55.0",
-    "rimraf": "^2.4.3",
+    "rimraf": "^2.5.2",
     "symlink-or-copy": "^1.0.1",
     "temp": "^0.8.3",
     "walk-sync": "^0.2.5"

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "broccoli-funnel": "0.2.8",
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
+    "broccoli-stew": "^1.2.0",
     "contextify": "^0.1.11",
     "ember-fastboot-server": "0.5.3",
     "express": "^4.8.5",

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -79,8 +79,7 @@ describe('generating package.json', function() {
   describe('with production FastBoot builds', function() {
 
     before(function() {
-      var rm = require('rimraf');
-      return app.runEmberCommand('build', '--environment', 'production');
+      return app.run('ember', 'build', '--environment', 'production');
     });
 
     // https://github.com/tildeio/ember-cli-fastboot/issues/102

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -79,7 +79,8 @@ describe('generating package.json', function() {
   describe('with production FastBoot builds', function() {
 
     before(function() {
-      return app.run('ember', 'build', '--environment', 'production');
+      var rm = require('rimraf');
+      return app.runEmberCommand('build', '--environment', 'production');
     });
 
     // https://github.com/tildeio/ember-cli-fastboot/issues/102

--- a/tests/fixtures/module-whitelist/ember-cli-build.js
+++ b/tests/fixtures/module-whitelist/ember-cli-build.js
@@ -1,0 +1,10 @@
+module.exports = function(defaults) {
+  var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+  var app = new EmberApp(defaults, {
+    fingerprint: {
+      generateAssetMap: true
+    }
+  });
+
+  return app.toTree();
+};


### PR DESCRIPTION
This should fix an issue where babel plugins get re-registered twice.
There's a myriad of situations where copying over the options from an
existing application could result in misconfigurd or duplicate builds.

Instead of ripping `options` off EmberApp, we use the function exported
by the Ember CLI application's `ember-cli-build.js` file to return a
broccli tree. This allows the app to use any broccoli plugins (without
creating an addon) and also re-runs any initialization steps we might
have missed by creating the `EmberApp` ourselves. This also eliminates
reliance on the private `javascript()` method on `EmberApp`.