### PR TITLE
Use gcc 4.8 in travis-ci

### DIFF
--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-cli-fastboot/files/.travis.yml
+++ b/blueprints/ember-cli-fastboot/files/.travis.yml
@@ -1,0 +1,31 @@
+
+---
+language: node_js
+node_js:
+  - "4"
+
+sudo: false
+
+cache:
+  directories:
+    - node_modules
+
+before_install:
+  - npm config set spin false
+  - npm install -g bower
+  - npm install phantomjs-prebuilt
+
+install:
+  - npm install
+  - bower install
+
+script:
+  - npm test
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - g++-4.8

--- a/blueprints/ember-cli-fastboot/index.js
+++ b/blueprints/ember-cli-fastboot/index.js
@@ -1,0 +1,9 @@
+/*jshint node:true*/
+module.exports = {
+  description: 'Installation blueprint for ember-cli-fastboot',
+  normalizeEntityName: function() {
+    // this prevents an error when the entityName is
+    // not specified (since that doesn't actually matter
+    // to us
+  }
+};


### PR DESCRIPTION
Currently, setting up ember-cli-fastboot with a new app will cause failures in travis-ci. This is because of [a known issue](https://github.com/nodejs/nan/issues/448), where a different C++ compiler is necessary to build native code in `nan` (a dependency of `contextify`). Potentially this problem arises with any kind of native code used w/ node-gyp in iojs3 or node4.

```
> contextify@0.1.15 install /home/travis/build/mike-north/peepchat-ui/node_modules/ember-cli-fastboot/node_modules/contextify
> node-gyp rebuild
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
gyp WARN download NVM_NODEJS_ORG_MIRROR is deprecated and will be removed in node-gyp v4, please use NODEJS_ORG_MIRROR
make: Entering directory `/home/travis/build/mike-north/peepchat-ui/node_modules/ember-cli-fastboot/node_modules/contextify/build'
  CXX(target) Release/obj.target/contextify/src/contextify.o
In file included from ../src/contextify.cc:3:0:
../node_modules/nan/nan.h:41:3: error: #error This version of node/NAN/v8 requires a C++11 compiler
In file included from /home/travis/.node-gyp/4.4.2/include/node/node.h:42:0,
                 from ../src/contextify.cc:1:
```

This new installation blueprint sets up travis-ci to use [the appropriate compiler](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Node.js-v4-(or-io.js-v3)-compiler-requirements) to compile native code  