### PR TITLE
Change the option passed to the server to point to `dist`

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -11,7 +11,7 @@ module.exports = {
     { name: 'serve-assets', type: Boolean, default: false },
     { name: 'host', type: String, default: '::' },
     { name: 'port', type: Number, default: 3000 },
-    { name: 'output-path', type: String, default: 'fastboot-dist' },
+    { name: 'output-path', type: String, default: 'dist' },
     { name: 'assets-path', type: String, default: 'dist' }
   ],
 

--- a/tests/acceptance/build-test.js
+++ b/tests/acceptance/build-test.js
@@ -17,7 +17,7 @@ describe('it builds', function() {
     return app.create('dummy');
   });
 
-  it("builds into fastboot-dist by default", function() {
+  it("builds into dist by default", function() {
     return app.runEmberCommand('build')
       .then(function() {
         expect(app.filePath('dist/index.html')).to.be.a.file();


### PR DESCRIPTION
The default option for `output-path` (which is used for the `distPath`
in the server) still pointed to `fastboot-dist`, while the build process
builds the assets within `build`

Also update the description of the test related to building