### PR TITLE
Get file paths from the `outputPaths` option in the build

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,7 @@ module.exports = {
       project: this.project,
       name: this.app.name,
       assetMapPath: this.assetMapPath,
+      outputPaths: this.app.options.outputPaths,
       ui: this.ui,
       fastbootAppConfig: this.project.config(env).fastboot
     });

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -13,6 +13,7 @@ function FastBootConfig(inputNode, options) {
   this.name = options.name;
   this.ui = options.ui;
   this.fastbootAppConfig = options.fastbootAppConfig;
+  this.outputPaths = options.outputPaths;
 }
 
 FastBootConfig.prototype = Object.create(Plugin.prototype);
@@ -90,8 +91,10 @@ FastBootConfig.prototype.readAssetManifest = function() {
 };
 
 FastBootConfig.prototype.buildManifest = function() {
-  var appFile = 'fastboot/' + this.name + '.js';
-  var vendorFile = 'fastboot/vendor.js';
+  var appFileName = path.basename(this.outputPaths.app.js).split('.')[0];
+  var appFile = 'fastboot/' + appFileName + '.js';
+  var vendorFileName = path.basename(this.outputPaths.vendor.js).split('.')[0];
+  var vendorFile = 'fastboot/' + vendorFileName + '.js';
 
   var manifest = {
     appFile: appFile,

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -128,6 +128,33 @@ describe('generating package.json', function() {
 
   });
 
+  describe('with customized outputPaths options', function() {
+    // Tests an app with a custom `outputPaths` set
+    var customApp = new AddonTestApp();
+
+    before(function() {
+      return customApp.create('customized-outputpaths')
+        .then(function() {
+          return customApp.run('ember', 'build', '--environment', 'production');
+        });
+    });
+
+    it("respects custom output paths and maps to them in the manifest", function() {
+
+      var p = function(filePath) {
+        return customApp.filePath(path.join('dist', filePath));
+      };
+
+      var pkg = fs.readJsonSync(customApp.filePath('/dist/package.json'));
+      var manifest = pkg.fastboot.manifest;
+
+      expect(p(manifest.appFile)).to.be.a.file();
+      expect(p(manifest.htmlFile)).to.be.a.file();
+      expect(p(manifest.vendorFile)).to.be.a.file();
+    });
+
+  });
+
 });
 
 function addFastBootDeps(app) {

--- a/tests/fixtures/customized-outputpaths/ember-cli-build.js
+++ b/tests/fixtures/customized-outputpaths/ember-cli-build.js
@@ -1,0 +1,22 @@
+/*jshint node:true*/
+/* global require, module */
+var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+
+module.exports = function(defaults) {
+  var app = new EmberApp(defaults, {
+    outputPaths: {
+      app: {
+        html: 'index.html',
+        css: {
+          'app': '/assets/app.css',
+        },
+        js: '/assets/app.js'
+      },
+      vendor: {
+        js: '/assets/lib.js'
+      }
+    }
+  });
+
+  return app.toTree();
+};


### PR DESCRIPTION
FastBoot would not have the correct information in the `package.json`'s
manifest if the user overrode the `outputPaths` options for app/vendor

Closes #163