### PR TITLE
Add Ember.onerror hook for fastboot apps to prevent node from crashing

### DIFF
--- a/app/initializers/fastboot/error-handler.js
+++ b/app/initializers/fastboot/error-handler.js
@@ -1,0 +1,20 @@
+import Ember from 'ember';
+
+/**
+ * Initializer to attach an `onError` hook to your app running in fastboot. It catches any run loop
+ * exceptions and other errors and prevents the node process from crashing.
+ *
+ */
+export default {
+  name: 'error-handler',
+
+  initialize: function(application) {
+    if (!Ember.onerror) {
+      // if no onerror handler is defined, define one for fastboot environments
+      Ember.onerror = function(err) {
+        let errorMessage = `There was an error running your app in fastboot. More info about the error: \n ${err.stack || err}`;
+        Ember.Logger.error(errorMessage);
+      }
+    }
+  }
+};

--- a/tests/acceptance/error-handler-test.js
+++ b/tests/acceptance/error-handler-test.js
@@ -1,0 +1,33 @@
+var expect           = require('chai').expect;
+var RSVP             = require('rsvp');
+var request          = RSVP.denodeify(require('request'));
+
+var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('error handler acceptance', function() {
+  this.timeout(300000);
+
+  var app;
+
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('error-handler')
+      .then(function() {
+        return app.startServer({
+          command: 'fastboot'
+        });
+      });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('visiting `/` does not result in an error', function() {
+    return request('http://localhost:49741/')
+      .then(function(response) {
+        expect(response.statusCode).to.equal(200);
+      });
+  });
+});

--- a/tests/fixtures/error-handler/app/routes/application.js
+++ b/tests/fixtures/error-handler/app/routes/application.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+
+  afterModel() {
+    Ember.run(function() {
+      // trigger a run loop error
+      let fooEl = Ember.$('foo.bar');
+    });
+  }
+});

--- a/tests/fixtures/error-handler/app/templates/head.hbs
+++ b/tests/fixtures/error-handler/app/templates/head.hbs
@@ -1,0 +1,1 @@
+<p>Hello World!</p>


### PR DESCRIPTION
This PR addresses the issue of node crashing when there is an exception running your app in fastboot environments.

When there are errors in the run loop due to accessing DOM API or any other errors, the node process crashes. This initializer catches and logs such errors and prevents the app from crashing.

I have manually tested it with a dummy app. When using the following code snippet in a model hook:
```Ember.run.later(this, function() {
      let fooEl = Ember.$('foo.bar');
    }, 1000);```

without this fix crashes the app.

Let me know if the error is not descriptive enough.

cc: @tomdale 