### PR TITLE
Fix deprecationAlias calls

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -27,8 +27,8 @@ const RequestObject = Ember.Object.extend({
 });
 
 export default Ember.Service.extend({
-  cookies: deprecatingAlias('cookies', 'request.cookies', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
-  headers: deprecatingAlias('headers', 'request.headers', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
+  cookies: deprecatingAlias('request.cookies', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
+  headers: deprecatingAlias('request.headers', { id: 'fastboot.headers-to-request', until: '0.9.9' }),
 
   host: computed(function() {
     deprecate(


### PR DESCRIPTION
Accidentally made an infinite loop in deprecation of
`fastboot.{cookies,headers}`