### PR TITLE
support inclusion as addon dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,10 @@ module.exports = {
    * we mixin additional Ember addon hooks appropriate to the current build target.
    */
   included: function(app) {
+    if (app.app) {
+      app = app.app;
+    }
+
     patchEmberApp(app);
 
     // We serve the index.html from fastboot-dist, so this has to apply to both builds


### PR DESCRIPTION
Similar to https://github.com/tomdale/ember-network/pull/6, build fails if you include an addon which, in turn, includes this addon.