### PR TITLE
Support storeConfigInMeta, add config to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,12 @@ module.exports = {
    */
   included: function(app) {
     patchEmberApp(app);
+  },
 
-    // We serve the index.html from fastboot-dist, so this has to apply to both builds
-    app.options.storeConfigInMeta = false;
+  config: function() {
+    if (this.app && this.app.options.__is_building_fastboot__) {
+      return { APP: { autoboot: false } };
+    }
   },
 
   /**
@@ -45,7 +48,7 @@ module.exports = {
    * to insert the rendered content into the right spot. Also injects a module
    * for FastBoot application boot.
    */
-  contentFor: function(type, config) {
+  contentFor: function(type, config, contents) {
     if (type === 'body') {
       return "<!-- EMBER_CLI_FASTBOOT_BODY -->";
     }
@@ -56,6 +59,17 @@ module.exports = {
 
     if (type === 'app-boot') {
       return fastbootAppModule(config.modulePrefix);
+    }
+
+    if (type === 'config-module' && this.app.options.__is_building_fastboot__) {
+      var linesToRemove = contents.length;
+      while(linesToRemove) {
+        // Clear out the default config from ember-cli
+        contents.pop();
+        linesToRemove--;
+      }
+
+      return 'return FastBoot.config();';
     }
   },
 

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -106,6 +106,8 @@ FastBootBuild.prototype.appOptions = function() {
 FastBootBuild.prototype.buildConfigTree = function(tree) {
   var FastBootConfig = require('./fastboot-config');
   var env = this.app.env;
+  var config = this.project.config(env);
+  var fastbootConfig = config.fastboot;
 
   // Create a new Broccoli tree that writes the FastBoot app's
   // `package.json`.
@@ -115,7 +117,8 @@ FastBootBuild.prototype.buildConfigTree = function(tree) {
     assetMapPath: this.assetMapPath,
     outputPaths: this.app.options.outputPaths,
     ui: this.ui,
-    fastbootAppConfig: this.project.config(env).fastboot
+    fastbootAppConfig: fastbootConfig,
+    appConfig: config
   });
 };
 
@@ -131,16 +134,8 @@ FastBootBuild.prototype.buildFastBootProject = function() {
   var Project = require('ember-cli/lib/models/project');
   var oldProject = this.project;
   var project = new Project(oldProject.root, oldProject.pkg, oldProject.ui, oldProject.cli);
-  project.config = function config() {
-    var config = Object.getPrototypeOf(this).config.apply(this, arguments);
 
-    config.APP = config.APP || {};
-    config.APP.autoboot = false;
-
-    return config;
-  };
-
-  return project;
+  return this.project = project;
 };
 
 module.exports = FastBootBuild;

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -14,6 +14,7 @@ function FastBootConfig(inputNode, options) {
   this.ui = options.ui;
   this.fastbootAppConfig = options.fastbootAppConfig;
   this.outputPaths = options.outputPaths;
+  this.appConfig = options.appConfig;
 }
 
 FastBootConfig.prototype = Object.create(Plugin.prototype);
@@ -135,7 +136,8 @@ FastBootConfig.prototype.toJSONString = function() {
     fastboot: {
       moduleWhitelist: this.moduleWhitelist,
       manifest: this.manifest,
-      hostWhitelist: this.normalizeHostWhitelist()
+      hostWhitelist: this.normalizeHostWhitelist(),
+      appConfig: this.appConfig
     }
   }, null, 2);
 };

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
     "broccoli-stew": "^1.2.0",
-    "ember-fastboot-server": "^0.7.2",
+    "ember-fastboot-server": "^0.7.3",
     "express": "^4.8.5",
     "fastboot-filter-initializers": "0.0.2",
     "lodash.clonedeep": "^4.3.1",

--- a/tests/acceptance/package-json-test.js
+++ b/tests/acceptance/package-json-test.js
@@ -74,6 +74,20 @@ describe('generating package.json', function() {
       ]);
     });
 
+    it("contains the application config", function() {
+      var pkg = fs.readJsonSync(app.filePath('dist/package.json'));
+
+      expect(pkg.fastboot.appConfig).to.deep.equal({
+        modulePrefix: 'module-whitelist',
+        environment: 'development',
+        baseURL: '/',
+        locationType: 'auto',
+        EmberENV: { FEATURES: {} },
+        APP: { name: 'module-whitelist', version: '0.0.0+', autoboot: false },
+        fastboot: { hostWhitelist: [ 'example.com', 'subdomain.example.com', {} ] },
+        exportApplicationGlobal: true
+      });
+    });
   });
 
   describe('with production FastBoot builds', function() {


### PR DESCRIPTION
Fixes #160

* Stop forcing `storeConfigInMeta` to false in the browser build
* Store the application config in `package.json`
* Bump `ember-fastboot-server` version to 0.7.3 ([diff from 0.7.2](https://github.com/ember-fastboot/ember-fastboot-server/compare/v0.7.2...v0.7.3))