### PR TITLE
FastBootLocation API

### DIFF
--- a/app/locations/none.js
+++ b/app/locations/none.js
@@ -1,0 +1,53 @@
+import Ember from 'ember';
+
+const {
+  computed,
+  computed: { reads },
+  inject: { service },
+  get,
+  getOwner
+} = Ember;
+
+export default Ember.NoneLocation.extend({
+  implementation: 'fastboot',
+  fastboot: service(),
+
+  _fastbootHeadersEnabled: computed(function () {
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return !!get(config, 'fastboot.fastbootHeaders');
+  }),
+
+  _redirectCode: computed(function () {
+    const TEMPORARY_REDIRECT_CODE = 307;
+    const config = getOwner(this).resolveRegistration('config:environment');
+    return get(config, 'fastboot.redirectCode') || TEMPORARY_REDIRECT_CODE;
+  }),
+
+  _response: reads('fastboot.response'),
+  _request: reads('fastboot.request'),
+
+  setURL(path) {
+    if (get(this, 'fastboot.isFastBoot')) {
+      const currentPath = get(this, 'path');
+      const isInitialPath = !currentPath || currentPath.length === 0;
+      const isTransitioning = currentPath !== path;
+      let response = get(this, '_response');
+
+      if (isTransitioning && !isInitialPath) {
+        let protocol = get(this, '_request.protocol');
+        let host = get(this, '_request.host');
+        let redirectURL = `${protocol}://${host}${path}`;
+
+        response.statusCode = this.get('_redirectCode');
+        response.headers.set('location', redirectURL);
+      }
+
+      // for testing and debugging
+      if(get(this, '_fastbootHeadersEnabled')) {
+        response.headers.set('x-fastboot-path', path);
+      }
+    }
+
+    this._super(...arguments);
+  }
+});

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
     "broccoli-stew": "^1.2.0",
-    "fastboot-express-middleware": "1.0.0-beta.5",
+    "fastboot-express-middleware": "1.0.0-beta.6",
     "ember-cli-babel": "^5.1.5",
     "ember-test-helpers": "^0.5.22",
     "express": "^4.8.5",

--- a/test/fastboot-location-config-test.js
+++ b/test/fastboot-location-config-test.js
@@ -1,0 +1,52 @@
+var chai = require('chai');
+var expect = chai.expect;
+var RSVP = require('rsvp');
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+var request = require('request');
+var get = RSVP.denodeify(request);
+
+describe('FastBootLocation Configuration', function () {
+  this.timeout(300000);
+
+  before(function () {
+    app = new AddonTestApp();
+
+    return app.create('fastboot-location-config')
+    .then(function () {
+      return app.startServer({
+        command: 'fastboot',
+        additionalArguments: ['--serve-assets']
+      });
+    });
+  });
+
+  after(function () {
+    return app.stopServer();
+  });
+
+  it('should use the redirect code provided by the EmberApp', function () {
+    return get({
+      url: 'http://localhost:49741/redirect-on-transition-to',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(302);
+    });
+  });
+
+  describe('when fastboot.fastbootHeaders is false', function () {
+    it('should not send the "x-fastboot-path" header on a redirect', function () {
+      return get({
+        url: 'http://localhost:49741/redirect-on-transition-to',
+        followRedirect: false
+      })
+      .then(function (response) {
+        if (response.statusCode === 500) throw new Error (response.body);
+        expect(response.headers).to.not.include.keys([
+          'x-fastboot-path'
+        ]);
+      });
+    });
+  });
+});

--- a/test/fastboot-location-test.js
+++ b/test/fastboot-location-test.js
@@ -1,0 +1,99 @@
+var chai = require('chai');
+var expect = chai.expect;
+var RSVP = require('rsvp');
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+var request = require('request');
+var get = RSVP.denodeify(request);
+
+describe('FastBootLocation', function () {
+  this.timeout(300000);
+
+  before(function () {
+    app = new AddonTestApp();
+
+    return app.create('fastboot-location')
+    .then(function () {
+      return app.startServer({
+        command: 'fastboot',
+        additionalArguments: ['--serve-assets']
+      });
+    });
+  });
+
+  after(function () {
+    return app.stopServer();
+  });
+
+  it('should NOT redirect when no transition is called', function () {
+    return get({
+      url: 'http://localhost:49741/test-passed',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal('/test-passed');
+
+      expect(response.body).to.contain('The Test Passed!');
+    });
+  });
+
+  it.skip('should NOT redirect when intermediateTransitionTo is called', function () {
+    return get({
+      url: 'http://localhost:49741/redirect-on-intermediate-transition-to',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal('/redirect-on-intermediate-transition-to');
+
+      expect(response.body).to.not.contain('Welcome to Ember');
+      expect(response.body).to.not.contain('The Test Passed!');
+    });
+  });
+
+  it('should redirect when transitionTo is called', function () {
+    return get({
+      url: 'http://localhost:49741/redirect-on-transition-to',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(307);
+
+      expect(response.headers).to.include.keys([
+        'location',
+        'x-fastboot-path'
+      ]);
+      expect(response.headers.location).to.equal('http://localhost:49741/test-passed');
+      expect(response.body).to.contain('Redirecting to');
+      expect(response.body).to.contain('/test-passed');
+    });
+  });
+
+  it('should redirect when replaceWith is called', function () {
+    return get({
+      url: 'http://localhost:49741/redirect-on-replace-with',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(307);
+
+      expect(response.headers).to.include.keys([
+        'location',
+        'x-fastboot-path'
+      ]);
+      expect(response.headers.location).to.equal('http://localhost:49741/test-passed');
+      expect(response.body).to.contain('Redirecting to');
+      expect(response.body).to.contain('/test-passed');
+    });
+  });
+});

--- a/test/fixtures/fastboot-location-config/app/router.js
+++ b/test/fixtures/fastboot-location-config/app/router.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+let Router = Ember.Router;
+
+Router.map(function() {
+  this.route('redirect-on-transition-to');
+  this.route('test-passed');
+});
+
+export default Router;

--- a/test/fixtures/fastboot-location-config/app/routes/redirect-on-transition-to.js
+++ b/test/fixtures/fastboot-location-config/app/routes/redirect-on-transition-to.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.transitionTo('test-passed');
+  }
+});

--- a/test/fixtures/fastboot-location-config/app/routes/test-passed.js
+++ b/test/fixtures/fastboot-location-config/app/routes/test-passed.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({});

--- a/test/fixtures/fastboot-location-config/app/templates/test-passed.hbs
+++ b/test/fixtures/fastboot-location-config/app/templates/test-passed.hbs
@@ -1,0 +1,4 @@
+<h1>The Test Passed!</h1>
+
+<p>All redirection tests should be set up to redirect here.</p>
+

--- a/test/fixtures/fastboot-location-config/config/environment.js
+++ b/test/fixtures/fastboot-location-config/config/environment.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    baseUrl: '/',
+    environment: environment,
+    modulePrefix: 'fastboot-location-config',
+    fastboot: {
+      fastbootHeaders: false,
+      hostWhitelist: [/localhost:\d+/],
+      redirectCode: 302,
+    }
+  };
+
+  return ENV;
+};

--- a/test/fixtures/fastboot-location/app/router.js
+++ b/test/fixtures/fastboot-location/app/router.js
@@ -1,0 +1,12 @@
+import Ember from 'ember';
+
+let Router = Ember.Router;
+
+Router.map(function() {
+  this.route('redirect-on-intermediate-transition-to');
+  this.route('redirect-on-transition-to');
+  this.route('redirect-on-replace-with');
+  this.route('test-passed');
+});
+
+export default Router;

--- a/test/fixtures/fastboot-location/app/routes/redirect-on-intermediate-transition-to.js
+++ b/test/fixtures/fastboot-location/app/routes/redirect-on-intermediate-transition-to.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.intermediateTransitionTo('test-passed');
+  }
+});

--- a/test/fixtures/fastboot-location/app/routes/redirect-on-replace-with.js
+++ b/test/fixtures/fastboot-location/app/routes/redirect-on-replace-with.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.replaceWith('test-passed');
+  }
+});

--- a/test/fixtures/fastboot-location/app/routes/redirect-on-transition-to.js
+++ b/test/fixtures/fastboot-location/app/routes/redirect-on-transition-to.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.transitionTo('test-passed');
+  }
+});

--- a/test/fixtures/fastboot-location/app/routes/test-passed.js
+++ b/test/fixtures/fastboot-location/app/routes/test-passed.js
@@ -1,0 +1,3 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({});

--- a/test/fixtures/fastboot-location/app/templates/redirect-on-intermediate-transition-to.hbs
+++ b/test/fixtures/fastboot-location/app/templates/redirect-on-intermediate-transition-to.hbs
@@ -1,0 +1,8 @@
+<h1>This content should never appear</h1>
+
+<p>
+  The route for this page does an intermediate transition.
+  This template should be replaced with the contents of
+  test-passed.hbs
+</p>
+

--- a/test/fixtures/fastboot-location/app/templates/test-passed.hbs
+++ b/test/fixtures/fastboot-location/app/templates/test-passed.hbs
@@ -1,0 +1,4 @@
+<h1>The Test Passed!</h1>
+
+<p>All redirection tests should be set up to redirect here.</p>
+

--- a/test/fixtures/fastboot-location/config/environment.js
+++ b/test/fixtures/fastboot-location/config/environment.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    baseUrl: '/',
+    environment: environment,
+    modulePrefix: 'fastboot-location',
+    fastboot: {
+      fastbootHeaders: true,
+      hostWhitelist: [/localhost:\d+/]
+    }
+  };
+
+  return ENV;
+};

--- a/tests/unit/locations/none-test.js
+++ b/tests/unit/locations/none-test.js
@@ -1,0 +1,12 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('location:none', 'Unit | Location | none in the browser', {
+  // Specify the other units that are required for this test.
+  needs: ['service:fastboot']
+});
+
+test('setURL ', function (assert) {
+  let location = this.subject();
+  location.setURL('foo');
+  assert.equal(location.get('path'), 'foo', 'it should execute and not call fastboot code');
+});


### PR DESCRIPTION
@rwjblue So this is a first draft. There are a couple of issues:

1. `replaceWith` and `intermediateTransitionTo` die hard. Specifically, `setURL` is not getting the path to redirect to when those two functions are called. Check the failing tests in TravisCI to see those examples.

2. `transitionTo` still renders the body. The middleware or fastboot could be modified to not include it, but a better solution would be to tell Ember to abort the page rendering. Tips on how to do that would be appreciated. I couldn't find anything straightforward in the docs.

If we can solve those, I can add a few more test cases (covering `model`, and `afterModel` hooks come to mind) and get this ready for submission.