### PR TITLE
Do not compute FastBootService.request in the browser

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -84,6 +84,7 @@ export default Ember.Service.extend({
   response: readOnly('_fastbootInfo.response'),
 
   request: computed(function() {
+    if (!get(this, 'isFastBoot')) return null;
     return RequestObject.create({ request: get(this, '_fastbootInfo.request') });
   }),
 

--- a/tests/unit/services/fastboot-test.js
+++ b/tests/unit/services/fastboot-test.js
@@ -1,0 +1,18 @@
+import { moduleFor, test } from 'ember-qunit';
+
+moduleFor('service:fastboot', 'Unit | Service | fastboot in the browser', {});
+
+test('isFastBoot', function(assert) {
+  let service = this.subject();
+  assert.equal(service.get('isFastBoot'), false, `it should be false`);
+});
+
+test('request', function(assert) {
+  let service = this.subject();
+  assert.equal(service.get('request'), null, `it should be null`);
+});
+
+test('response', function(assert) {
+  let service = this.subject();
+  assert.equal(service.get('response'), null, `it should be null`);
+});


### PR DESCRIPTION
@danmcclain Whenever `FastBootService.request` was accessed in the browser, it was not handling `_fastbootInfo.request` being `undefined`. This fix ensures that we return `null` in that case just like `Ember.computed.readOnly` would.