### PR TITLE
Specify localhost as default host

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -9,7 +9,7 @@ module.exports = {
     { name: 'build', type: Boolean, default: true },
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'serve-assets', type: Boolean, default: false },
-    { name: 'host', type: String, default: 'localhost' },
+    { name: 'host', type: String, default: '::1' },
     { name: 'port', type: Number, default: 3000 },
     { name: 'output-path', type: String, default: 'dist' },
     { name: 'assets-path', type: String, default: 'dist' }

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -9,7 +9,7 @@ module.exports = {
     { name: 'build', type: Boolean, default: true },
     { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'serve-assets', type: Boolean, default: false },
-    { name: 'host', type: String, default: '::' },
+    { name: 'host', type: String, default: 'localhost' },
     { name: 'port', type: Number, default: 3000 },
     { name: 'output-path', type: String, default: 'dist' },
     { name: 'assets-path', type: String, default: 'dist' }

--- a/test/async-content-test.js
+++ b/test/async-content-test.js
@@ -29,7 +29,7 @@ describe('async content via deferred content', function() {
 
   it('waits for async content when using `fastboot.deferRendering`', function() {
     return get({
-      url: 'http://localhost:49741/'
+      url: 'http://::1:49741/'
     })
       .then(function(response) {
         expect(response.body).to.contain('Async content: foo');

--- a/test/error-handler-test.js
+++ b/test/error-handler-test.js
@@ -25,7 +25,7 @@ describe('error handler acceptance', function() {
   });
 
   it('visiting `/` does not result in an error', function() {
-    return request('http://localhost:49741/')
+    return request('http://::1:49741/')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
       });

--- a/test/fixtures/module-whitelist/config/environment.js
+++ b/test/fixtures/module-whitelist/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
     },
 
     fastboot: {
-      hostWhitelist: ['example.com', 'subdomain.example.com', /localhost:\d+/]
+      hostWhitelist: ['example.com', 'subdomain.example.com', /::1:\d+/]
     }
   };
 

--- a/test/fixtures/request/config/environment.js
+++ b/test/fixtures/request/config/environment.js
@@ -19,7 +19,7 @@ module.exports = function(environment) {
     },
 
     fastboot: {
-      hostWhitelist: ['example.com', 'subdomain.example.com', /localhost:\d+/]
+      hostWhitelist: ['example.com', 'subdomain.example.com', /::1:\d+/]
     }
   };
 

--- a/test/head-content-test.js
+++ b/test/head-content-test.js
@@ -26,7 +26,7 @@ describe('head content acceptance', function() {
   });
 
   it('/ Has head content replaced', function() {
-    return request('http://localhost:49741/')
+    return request('http://::1:49741/')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -70,7 +70,7 @@ describe('generating package.json', function() {
       expect(pkg.fastboot.hostWhitelist).to.deep.equal([
         'example.com',
         'subdomain.example.com',
-        '/localhost:\\d+/'
+        '/::1:\\d+/'
       ]);
     });
 

--- a/test/request-details-test.js
+++ b/test/request-details-test.js
@@ -29,17 +29,17 @@ describe('request details', function() {
 
   it('makes host available via a service', function() {
     return get({
-      url: 'http://localhost:49741/show-host'
+      url: 'http://::1:49741/show-host'
     })
       .then(function(response) {
-        expect(response.body).to.contain('Host: localhost:49741');
-        expect(response.body).to.contain('Host from Instance Initializer: localhost:49741');
+        expect(response.body).to.contain('Host: ::1:49741');
+        expect(response.body).to.contain('Host from Instance Initializer: ::1:49741');
       });
   });
 
   it('makes protocol available via a service', function() {
     return get({
-      url: 'http://localhost:49741/show-protocol'
+      url: 'http://::1:49741/show-protocol'
     })
       .then(function(response) {
         expect(response.body).to.contain('Protocol: http');
@@ -49,7 +49,7 @@ describe('request details', function() {
 
   it('makes path available via a service', function() {
     return get({
-      url: 'http://localhost:49741/show-path'
+      url: 'http://::1:49741/show-path'
     })
       .then(function(response) {
         expect(response.body).to.contain('Path: /show-path');
@@ -59,7 +59,7 @@ describe('request details', function() {
 
   it('makes query params available via a service', function() {
     return get({
-      url: 'http://localhost:49741/list-query-params?foo=bar'
+      url: 'http://::1:49741/list-query-params?foo=bar'
     })
       .then(function(response) {
         expect(response.body).to.contain('Query Params: bar');
@@ -71,10 +71,10 @@ describe('request details', function() {
     var jar = request.jar();
     var cookie = request.cookie('city=Cluj');
 
-    jar.setCookie(cookie, 'http://localhost:49741');
+    jar.setCookie(cookie, 'http://::1:49741');
 
     return get({
-      url: 'http://localhost:49741/list-cookies',
+      url: 'http://::1:49741/list-cookies',
       jar: jar
     })
       .then(function(response) {
@@ -85,7 +85,7 @@ describe('request details', function() {
 
   it('makes headers available via a service', function() {
     return get({
-      url: 'http://localhost:49741/list-headers',
+      url: 'http://::1:49741/list-headers',
       headers: { 'X-FastBoot-info': 'foobar' }
     })
       .then(function(response) {

--- a/test/response-details-test.js
+++ b/test/response-details-test.js
@@ -29,7 +29,7 @@ describe('response details', function() {
 
   it('makes headers available via a service', function() {
     return get({
-      url: 'http://localhost:49741/echo-request-headers',
+      url: 'http://::1:49741/echo-request-headers',
       headers: { 'X-FastBoot-echo': 'i-should-be-echoed-back' }
     })
       .then(function(response) {
@@ -40,7 +40,7 @@ describe('response details', function() {
 
   it('makes the status code available via a service', function() {
     return get({
-      url: 'http://localhost:49741/return-status-code-418'
+      url: 'http://::1:49741/return-status-code-418'
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(418);

--- a/test/serve-assets-test.js
+++ b/test/serve-assets-test.js
@@ -27,7 +27,7 @@ describe('serve assets acceptance', function() {
   });
 
   it('/assets/vendor.js', function() {
-    return request('http://localhost:49741/assets/vendor.js')
+    return request('http://::1:49741/assets/vendor.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("application/javascript");
@@ -36,7 +36,7 @@ describe('serve assets acceptance', function() {
   });
 
   it('/assets/dummy.js', function() {
-    return request('http://localhost:49741/assets/dummy.js')
+    return request('http://::1:49741/assets/dummy.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("application/javascript");

--- a/test/shoebox-put-test.js
+++ b/test/shoebox-put-test.js
@@ -25,7 +25,7 @@ describe('shoebox - put', function() {
   });
 
   it('put items into the shoebox', function() {
-    return request('http://localhost:49741/')
+    return request('http://::1:49741/')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.body).to.contain(

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -25,7 +25,7 @@ describe('simple acceptance', function() {
   });
 
   it('/ HTML contents', function() {
-    return request('http://localhost:49741/')
+    return request('http://::1:49741/')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
@@ -34,7 +34,7 @@ describe('simple acceptance', function() {
   });
 
   it('/posts HTML contents', function() {
-    return request('http://localhost:49741/posts')
+    return request('http://::1:49741/posts')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
         expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
@@ -44,7 +44,7 @@ describe('simple acceptance', function() {
   });
 
   it('/not-found HTML contents', function() {
-    return request('http://localhost:49741/not-found')
+    return request('http://::1:49741/not-found')
       .then(function(response) {
         expect(response.statusCode).to.equal(404);
         expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
@@ -53,7 +53,7 @@ describe('simple acceptance', function() {
   });
 
   it('/boom HTML contents', function() {
-    return request('http://localhost:49741/boom')
+    return request('http://::1:49741/boom')
       .then(function(response) {
         expect(response.statusCode).to.equal(500);
         expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
@@ -62,7 +62,7 @@ describe('simple acceptance', function() {
   });
 
   it('/assets/vendor.js', function() {
-    return request('http://localhost:49741/assets/vendor.js')
+    return request('http://::1:49741/assets/vendor.js')
       .then(function(response) {
         // Asset serving is off by default
         expect(response.statusCode).to.equal(404);


### PR DESCRIPTION
IMHO, "localhost" or "127.0.0.1" should be the default address that gets used when serving an ember app using FastBoot (instead of "::", which allows connections on any IPv6/IPv4 address by default).

Devs will still be able to specify a different host (or "::" for all) using `--host`.

**BEFORE**
```
Ember FastBoot running at http://[::]:3000
```

**AFTER**

```
Ember FastBoot running at http://127.0.0.1:3000
```

By the way, I've also considered simply adding an if-statement to the method that logs the message which replaces the host with "localhost" if the original value is "::". But in my opinion, that's not a good solution because "::" allows connections over all addresses, not just the localhost one.

A nice side-effect of this change is that the user will be able to click the address within the command line to open it in the browser using `doubleclick` + `cmd`.

Besides of that, it might also be a little more secure because the app will only be available on the exact address shown in the logged message.