### PR TITLE
Remove stray whitespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ export default Ember.Route.extend({
 });
 ```
 
- ### The Shoebox
+### The Shoebox
 
 You can pass application state from the FastBoot rendered application
 to the browser rendered application using a feature called the "Shoebox".


### PR DESCRIPTION
Starting a line with a space was preventing the markdown to be interpreted.