### PR TITLE
Use fastbootAppConfig.htmlFile if present

### DIFF
--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -17,6 +17,12 @@ function FastBootConfig(inputNode, options) {
   this.outputPaths = options.outputPaths;
   this.appConfig = options.appConfig;
   this._fileToChecksumMap = {};
+
+  if (this.fastbootAppConfig && this.fastbootAppConfig.htmlFile) {
+    this.htmlFile = this.fastbootAppConfig.htmlFile;
+  } else {
+    this.htmlFile = 'index.html';
+  }
 }
 
 FastBootConfig.prototype = Object.create(Plugin.prototype);
@@ -111,7 +117,7 @@ FastBootConfig.prototype.buildManifest = function() {
   var manifest = {
     appFile: appFile,
     vendorFile: vendorFile,
-    htmlFile: 'index.html'
+    htmlFile: this.htmlFile
   };
 
   var rewrittenAssets = this.readAssetManifest();

--- a/test/custom-html-file-test.js
+++ b/test/custom-html-file-test.js
@@ -1,0 +1,37 @@
+var expect           = require('chai').expect;
+var RSVP             = require('rsvp');
+var request          = RSVP.denodeify(require('request'));
+
+var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('custom htmlFile', function() {
+  this.timeout(300000);
+
+  var app;
+
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('custom-html-file')
+      .then(function() {
+        return app.startServer({
+          command: 'fastboot'
+        });
+      });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('uses custom htmlFile', function() {
+    return request('http://localhost:49741/')
+      .then(function(response) {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+
+        expect(response.body).to.contain("<title>custom index</title>");
+        expect(response.body).to.contain("<h1>application template</h1>");
+      });
+  });
+});

--- a/test/fixtures/custom-html-file/app/app.js
+++ b/test/fixtures/custom-html-file/app/app.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+import Resolver from 'ember/resolver';
+import loadInitializers from 'ember/load-initializers';
+import config from './config/environment';
+
+Ember.MODEL_FACTORY_INJECTIONS = true;
+
+var App = Ember.Application.extend({
+  modulePrefix: config.modulePrefix,
+  podModulePrefix: config.podModulePrefix,
+  Resolver: Resolver
+});
+
+loadInitializers(App, config.modulePrefix);
+
+export default App;

--- a/test/fixtures/custom-html-file/app/index.html
+++ b/test/fixtures/custom-html-file/app/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>Ignored Index.html</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    {{content-for 'head'}}
+
+    <link rel="stylesheet" href="assets/vendor.css">
+    <link rel="stylesheet" href="assets/custom-html-file.css">
+
+    {{content-for 'head-footer'}}
+  </head>
+  <body>
+    {{content-for 'body'}}
+
+    <script src="assets/vendor.js"></script>
+    <script src="assets/custom-html-file.js"></script>
+
+    {{content-for 'body-footer'}}
+  </body>
+</html>

--- a/test/fixtures/custom-html-file/app/router.js
+++ b/test/fixtures/custom-html-file/app/router.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import config from './config/environment';
+
+var Router = Ember.Router.extend({
+  location: config.locationType
+});
+
+Router.map(function() {
+});
+
+export default Router;

--- a/test/fixtures/custom-html-file/app/templates/application.hbs
+++ b/test/fixtures/custom-html-file/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h1>application template</h1>
+
+{{outlet}}

--- a/test/fixtures/custom-html-file/config/environment.js
+++ b/test/fixtures/custom-html-file/config/environment.js
@@ -1,0 +1,16 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'custom-html-file',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+
+    fastboot: {
+      htmlFile: 'custom-index.html'
+    }
+  };
+
+  return ENV;
+};

--- a/test/fixtures/custom-html-file/public/custom-index.html
+++ b/test/fixtures/custom-html-file/public/custom-index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>custom index</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+    <!-- EMBER_CLI_FASTBOOT_HEAD -->
+
+    <link rel="stylesheet" href="assets/vendor.css">
+    <link rel="stylesheet" href="assets/custom-html-file.css">
+  </head>
+  <body>
+    <!-- EMBER_CLI_FASTBOOT_BODY -->
+
+    <script src="assets/vendor.js"></script>
+    <script src="assets/custom-html-file.js"></script>
+  </body>
+</html>

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -169,6 +169,32 @@ describe('generating package.json', function() {
 
   });
 
+  describe('with custom htmlFile', function() {
+    this.timeout(300000);
+
+    var customApp = new AddonTestApp();
+
+    before(function() {
+      return customApp.create('custom-html-file')
+        .then(function() {
+          return customApp.run('ember', 'build', '--environment', 'production');
+        });
+    });
+
+    it("uses custom htmlFile in the manifest", function() {
+
+      var p = function(filePath) {
+        return customApp.filePath(path.join('dist', filePath));
+      };
+
+      var pkg = fs.readJsonSync(customApp.filePath('/dist/package.json'));
+      var manifest = pkg.fastboot.manifest;
+
+      expect(manifest.htmlFile).to.equal('custom-index.html');
+      expect(p(manifest.htmlFile)).to.be.a.file();
+    });
+
+  });
 });
 
 function addFastBootDeps(app) {


### PR DESCRIPTION
This change allows someone to add a `fastboot: { htmlFile: 'some-other-file.html' }` section to their ember app's `config/environment.js` and ember-cli-fastboot will use it instead of the default `index.html` file. The use case I'm aiming for is using fastboot to rember an ember app's body into a different HTML shell — for instance Google's AMP requires its own special HTML boilerplate, so in order to use ember-cli-fastboot to render a valid AMP page, it must insert the app's result into a different HTML file.

Is this a viable method to achieve that goal? If so I can add some tests to this PR.