### PR TITLE
server task's start shouldn't resolve until listening

### DIFF
--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -54,13 +54,17 @@ module.exports = CoreObject.extend({
           });
         });
 
-        this.httpServer.listen(options.port, options.host, () => {
-          const o = this.httpServer.address();
-          const port = o.port;
-          const family = o.family;
-          let host = o.address;
-          if (family === 'IPv6') { host = `[${host}]`; }
-          this.ui.writeLine(`Ember FastBoot running at http://${host}:${port}`);
+        return new RSVP.Promise((resolve, reject) => {
+          this.httpServer.listen(options.port, options.host, (err) => {
+            if (err) { return reject(err); }
+            const o = this.httpServer.address();
+            const port = o.port;
+            const family = o.family;
+            let host = o.address;
+            if (family === 'IPv6') { host = `[${host}]`; }
+            this.ui.writeLine(`Ember FastBoot running at http://${host}:${port}`);
+            resolve();
+          });
         });
       });
   },

--- a/test/lib-tasks-fastboot-server-test.js
+++ b/test/lib-tasks-fastboot-server-test.js
@@ -20,7 +20,12 @@ function CommandOptions(options) {
 };
 function MockServer() {
   EventEmitter.apply(this, arguments);
-  this.listen = () => {};
+  this.listen = (port, host, callback) => {
+    RSVP.Promise.resolve().then(function() {
+      callback();
+    });
+  };
+  this.address = () => ({ port: 1, host: '0.0.0.0', family: 'IPv4' });
 }
 MockServer.prototype = Object.create(EventEmitter.prototype);
 const mockUI = { writeLine() {} };


### PR DESCRIPTION
I was glad to see the new fastboot-server Task, and I started experimenting with using it in a test harness. In the process I noticed this asynchrony bug.

Without this you can't reliably wait until the server is listening before sending in a request or telling it to stop.