### PR TITLE
Cautioning use of prototype extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,7 +381,7 @@ present.
 
 Prototype extensions do not currently work across node "realms."  Fastboot 
 applications operate in two realms, a normal node environment and a [virtual machine](https://nodejs.org/api/vm.html).  Passing objects that originated from the normal realm will not contain the extension methods
-inside of the sandbox environment. For this reason, it's encouraged to [disable prototype extensions](https://guides.emberjs.com/v2.3.0/configuring-ember/disabling-prototype-extensions/).
+inside of the sandbox environment. For this reason, it's encouraged to [disable prototype extensions](https://guides.emberjs.com/v2.4.0/configuring-ember/disabling-prototype-extensions/).
 
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -377,6 +377,12 @@ supported when running in FastBoot mode. One exception is network code for
 fetching models, which we intended to support, but doesn't work at
 present.
 
+### Prototype extensions
+
+Prototype extensions do not currently work across node "realms."  Fastboot 
+applications operate in two realms, a normal node environment and a [virtual machine](https://nodejs.org/api/vm.html).  Passing objects that originated from the normal realm will not contain the extension methods
+inside of the sandbox environment. For this reason, it's encouraged to [disable prototype extensions](https://guides.emberjs.com/v2.3.0/configuring-ember/disabling-prototype-extensions/).
+
 
 ## Troubleshooting
 


### PR DESCRIPTION
Based on the last meeting, adding to the README to caution that prototype extensions cannot be reliably used.
