### PR TITLE
Emit SIGHUP only if listeners exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,15 @@ module.exports = {
   },
 
   postBuild: function() {
-    process.emit('SIGHUP');
+    /**
+     * Note, only emit SIGHUP if there is a listener since the
+     * default behavior is to terminate the process if no listeners exist
+     *
+     * See: https://nodejs.org/api/process.html
+     */
+    if (process.listenerCount('SIGHUP')) {
+      process.emit('SIGHUP');
+    }
   },
 
 };


### PR DESCRIPTION
> On non-Windows platforms, the default behavior of SIGHUP is to terminate Node.js, but once a listener has been installed its default behavior will be removed.

Fixes #232