### PR TITLE
Replace SIGHUP event with a custom event

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* jshint node: true */
 'use strict';
 
+var EventEmitter = require('events').EventEmitter;
 var mergeTrees = require('broccoli-merge-trees');
 
 var patchEmberApp     = require('./lib/ext/patch-ember-app');
@@ -16,13 +17,27 @@ var FastBootBuild      = require('./lib/broccoli/fastboot-build');
 module.exports = {
   name: 'ember-cli-fastboot',
 
+  init() {
+    this._super.init && this._super.init.apply(this, arguments);
+
+    this.emitter = new EventEmitter();
+  },
+
   includedCommands: function() {
     return {
-      'fastboot':       require('./lib/commands/fastboot'),
+      'fastboot':       require('./lib/commands/fastboot')(this),
 
       /* fastboot:build is deprecated and will be removed in a future version */
       'fastboot:build': require('./lib/commands/fastboot-build')
     };
+  },
+
+  on: function() {
+    this.emitter.on.apply(this.emitter, arguments);
+  },
+
+  emit: function() {
+    this.emitter.emit.apply(this.emitter, arguments);
   },
 
   /**
@@ -109,7 +124,7 @@ module.exports = {
   },
 
   postBuild: function() {
-    process.emit('SIGHUP');
+    this.emit('postBuild');
   },
 
 };

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -8,63 +8,66 @@ const SilentError = require('silent-error');
 const blockForever = () => (new RSVP.Promise(() => {}));
 const noop = function() { };
 
-module.exports = {
-  name: 'fastboot',
-  description: 'Builds and serves your FastBoot app, rebuilding on file changes.',
+module.exports = function(addon) {
+  return {
+    name: 'fastboot',
+    description: 'Builds and serves your FastBoot app, rebuilding on file changes.',
 
-  availableOptions: [
-    { name: 'build', type: Boolean, default: true },
-    { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
-    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
-    { name: 'serve-assets', type: Boolean, default: false },
-    { name: 'host', type: String, default: '::' },
-    { name: 'port', type: Number, default: 3000 },
-    { name: 'output-path', type: String, default: 'dist' },
-    { name: 'assets-path', type: String, default: 'dist' }
-  ],
+    availableOptions: [
+      { name: 'build', type: Boolean, default: true },
+      { name: 'watch', type: Boolean, default: true, aliases: ['w'] },
+      { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
+      { name: 'serve-assets', type: Boolean, default: false },
+      { name: 'host', type: String, default: '::' },
+      { name: 'port', type: Number, default: 3000 },
+      { name: 'output-path', type: String, default: 'dist' },
+      { name: 'assets-path', type: String, default: 'dist' }
+    ],
 
-  blockForever,
-  getPort,
-  ServerTask,
+    blockForever,
+    getPort,
+    ServerTask,
 
-  run(options) {
-    const runBuild = () => this.runBuild(options);
-    const runServer = () => this.runServer(options);
-    const blockForever = this.blockForever;
+    run(options) {
+      const runBuild = () => this.runBuild(options);
+      const runServer = () => this.runServer(options);
+      const blockForever = this.blockForever;
 
-    return this.checkPort(options)
-      .then(runServer) // starts on postBuild SIGHUP
-      .then(options.build ? runBuild : noop)
-      .then(blockForever);
-  },
+      return this.checkPort(options)
+        .then(runServer) // starts on postBuild SIGHUP
+        .then(options.build ? runBuild : noop)
+        .then(blockForever);
+    },
 
-  runServer(options) {
-    const ServerTask = this.ServerTask;
-    const serverTask = new ServerTask({
-      ui: this.ui,
-    });
-    return serverTask.run(options);
-  },
-
-  runBuild(options) {
-    const BuildTask = options.watch ? this.tasks.BuildWatch : this.tasks.Build;
-    const buildTask = new BuildTask({
-      ui: this.ui,
-      analytics: this.analytics,
-      project: this.project,
-    });
-    buildTask.run(options); // no return, BuildWatch.run blocks forever
-  },
-
-  checkPort(options) {
-    return this.getPort({ port: options.port, host: options.host })
-      .then((foundPort) => {
-        if (options.port !== foundPort && options.port !== 0) {
-          const message = `Port ${options.port} is already in use.`;
-          return Promise.reject(new SilentError(message));
-        }
-        options.port = foundPort;
+    runServer(options) {
+      const ServerTask = this.ServerTask;
+      const serverTask = new ServerTask({
+        ui: this.ui,
+        addon: addon
       });
-  },
+      return serverTask.run(options);
+    },
 
+    runBuild(options) {
+      const BuildTask = options.watch ? this.tasks.BuildWatch : this.tasks.Build;
+      const buildTask = new BuildTask({
+        ui: this.ui,
+        analytics: this.analytics,
+        project: this.project,
+      });
+      buildTask.run(options); // no return, BuildWatch.run blocks forever
+    },
+
+    checkPort(options) {
+      return this.getPort({ port: options.port, host: options.host })
+        .then((foundPort) => {
+          if (options.port !== foundPort && options.port !== 0) {
+            const message = `Port ${options.port} is already in use.`;
+            return Promise.reject(new SilentError(message));
+          }
+          options.port = foundPort;
+        });
+    },
+
+  }
 };

--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -21,7 +21,7 @@ module.exports = CoreObject.extend({
   run(options) {
     debug('run');
     const restart = () => this.restart(options);
-    process.on('SIGHUP', restart);
+    this.addon.on('postBuild', restart);
   },
 
   start(options) {
@@ -120,6 +120,5 @@ module.exports = CoreObject.extend({
         delete require.cache[key];
       }
     });
-  },
-
+  }
 });

--- a/test/lib-commands-fastboot-test.js
+++ b/test/lib-commands-fastboot-test.js
@@ -4,7 +4,7 @@ const CoreObject = require('core-object');
 const camelize = require('ember-cli-string-utils').camelize;
 const defaults = require('lodash.defaults');
 const expect = require('chai').expect;
-const FastbootCommand = CoreObject.extend(require('../lib/commands/fastboot'));
+const FastbootCommand = CoreObject.extend(require('../lib/commands/fastboot')());
 const RSVP = require('rsvp');
 
 function CommandOptions(options) {

--- a/test/lib-tasks-fastboot-server-test.js
+++ b/test/lib-tasks-fastboot-server-test.js
@@ -5,7 +5,7 @@ const camelize = require('ember-cli-string-utils').camelize;
 const defaults = require('lodash.defaults');
 const EventEmitter = require('events').EventEmitter;
 const expect = require('chai').expect;
-const FastbootCommand = CoreObject.extend(require('../lib/commands/fastboot'));
+const FastbootCommand = CoreObject.extend(require('../lib/commands/fastboot')());
 const FastbootServerTask = require('../lib/tasks/fastboot-server');
 const http = require('http');
 const RSVP = require('rsvp');
@@ -28,15 +28,23 @@ function MockServer() {
   this.address = () => ({ port: 1, host: '0.0.0.0', family: 'IPv4' });
 }
 MockServer.prototype = Object.create(EventEmitter.prototype);
+
+function MockAddon() {
+  this.emitter = EventEmitter.apply(this, arguments);
+}
+
+MockAddon.prototype = Object.create(EventEmitter.prototype);
+
 const mockUI = { writeLine() {} };
 
 describe('fastboot server task', function() {
   let options, task;
-
+  let addon = new MockAddon();
   beforeEach(function() {
     this.sinon = sinon.sandbox.create();
     task = new FastbootServerTask({
       ui: mockUI,
+      addon: addon
     });
     options = new CommandOptions();
   });
@@ -46,10 +54,10 @@ describe('fastboot server task', function() {
   });
 
   describe('run', function() {
-    it('calls restart on SIGHUP', function() {
+    it('calls restart on postBuild', function() {
       const restartStub = this.sinon.stub(task, 'restart');
       task.run(options);
-      process.emit('SIGHUP');
+      addon.emit('postBuild');
       expect(restartStub.called).to.be.ok;
     });
   });


### PR DESCRIPTION
This removes signalling across the process, since `SIGHUP` will terminate the process if nothing subscribes to this event ([only on POSIX](https://nodejs.org/api/process.html)).

> On non-Windows platforms, the default behavior of SIGHUP is to terminate Node.js, but once a listener has been installed its default behavior will be removed.

So, in the case of `ember test` nothing is subscribed so it terminates the process after the build completes and before the test run.

Unfortunately, counting listeners also does not work (reliably) since testem uses `signal-exit` which will make the count `1` when testing.  And by default, `signal-exit` also terminates the process if no others are subscribed.

This change moves off `process.emit` in place of custom eventing on the addon instance.

Fixes #232

Review with https://github.com/ember-fastboot/ember-cli-fastboot/pull/234/files?w=1 since one file contained a mixture of tabs/spaces and my editor normalized them all to spaces.

/cc @rwjblue 