### PR TITLE
Revert "Use outputReady instead of postBuild"

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,8 +123,8 @@ module.exports = {
     return fastbootBuild.toTree();
   },
 
-  outputReady: function() {
-    this.emit('outputReady');
-  }
+  postBuild: function() {
+    this.emit('postBuild');
+  },
 
 };

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -34,7 +34,7 @@ module.exports = function(addon) {
       const blockForever = this.blockForever;
 
       return this.checkPort(options)
-        .then(runServer) // starts on outputReady event
+        .then(runServer) // starts on postBuild SIGHUP
         .then(options.build ? runBuild : noop)
         .then(blockForever);
     },

--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -21,7 +21,7 @@ module.exports = CoreObject.extend({
   run(options) {
     debug('run');
     const restart = () => this.restart(options);
-    this.addon.on('outputReady', restart);
+    this.addon.on('postBuild', restart);
   },
 
   start(options) {

--- a/test/lib-tasks-fastboot-server-test.js
+++ b/test/lib-tasks-fastboot-server-test.js
@@ -54,10 +54,10 @@ describe('fastboot server task', function() {
   });
 
   describe('run', function() {
-    it('calls restart on outputReady', function() {
+    it('calls restart on postBuild', function() {
       const restartStub = this.sinon.stub(task, 'restart');
       task.run(options);
-      addon.emit('outputReady');
+      addon.emit('postBuild');
       expect(restartStub.called).to.be.ok;
     });
   });


### PR DESCRIPTION
Reverts ember-fastboot/ember-cli-fastboot#238

There are some reports of this breaking live-reload/reload functionality.  Reverting for now (though I still believe it to be the correct solution) so we can track down the underlying issues separately.