### PR TITLE
Better shoebox API

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -1,8 +1,9 @@
 /* global FastBoot */
 import Ember from "ember";
 
-const { deprecate, computed, get } = Ember;
+const { deprecate, computed, get, RSVP } = Ember;
 const { deprecatingAlias, readOnly } = computed;
+const { Promise } = RSVP;
 
 const RequestObject = Ember.Object.extend({
   init() {
@@ -57,6 +58,15 @@ const Shoebox = Ember.Object.extend({
     this.set(key, shoeboxItem);
 
     return shoeboxItem;
+  },
+
+  has(key) {
+    if (this.get('fastboot.isFastBoot')) {
+      let shoebox = this.get('fastboot._fastbootInfo.shoebox');
+      return shoebox && shoebox.hasOwnProperty(key);
+    } else {
+      return !!document.querySelector(`#shoebox-${key}`);
+    }
   }
 });
 
@@ -95,5 +105,21 @@ export default Ember.Service.extend({
   deferRendering(promise) {
     Ember.assert('deferRendering requires a promise or thennable object', typeof promise.then === 'function');
     this._fastbootInfo.deferRendering(promise);
+  },
+
+  withShoebox(key, fn) {
+    return new Promise((resolve, reject) => {
+      let shoebox = this.get('shoebox');
+      if (shoebox.has(key)) {
+        resolve(shoebox.retrieve(key));
+        return;
+      }
+      Promise.resolve(fn()).then(value => {
+        if (this.get('isFastBoot')) {
+          shoebox.put(key, value);
+        }
+        return value;
+      }).then(resolve, reject);
+    });
   }
 });


### PR DESCRIPTION
This adds a new higher-level API for the shoebox.

```js
  model() {
    let fastboot = this.get('fastboot');
    return RSVP.hash({
      // In this example, we generate a random number once on the server,
      // and then the  client app will receive the same number.
      random: fastboot.withShoebox('my-random-number', () => Math.random())
    });
  }
```

`withShoebox` acts as a memoization service. On the server, the given callback will run and generate a value, which will be saved in the shoebox and then returned. On the client, the callback will not run if the value is already present in the shoebox.

`withShoebox` returns a promise, because the callback is allowed to return a promise.