### PR TITLE
[fix] package-json-test.js

### DIFF
--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -16,9 +16,6 @@ describe('generating package.json', function() {
 
     return app.create('module-whitelist')
       .then(addFastBootDeps)
-      .then(function() {
-        return app.run('npm', 'install');
-      });
   });
 
   describe('with FastBoot builds', function() {


### PR DESCRIPTION
I just tried to run this test locally and it failed since we have:

```
        "foo": "1.2.3",
        "bar": "^7.8.9",
        "baz": "0.2.0",
```

in the fixture app's `package.json`. 