### PR TITLE
Handle fingerprinted asset maps

### DIFF
--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -24,6 +24,8 @@ function FastBootBuild(options) {
   })[0];
 
   if (assetRev && assetRev.options) {
+    this.assetMapEnabled = !!(assetRev.options.enabled && assetRev.options.assetMapPath);
+
     if (assetRev.options.assetMapPath) {
       this.assetMapPath = assetRev.options.assetMapPath;
     }
@@ -118,7 +120,7 @@ FastBootBuild.prototype.buildConfigTree = function(tree) {
   return new FastBootConfig(tree, {
     project: this.project,
     name: this.app.name,
-    assetMapPath: this.assetMapPath,
+    assetMapEnabled: this.assetMapEnabled,
     outputPaths: this.app.options.outputPaths,
     ui: this.ui,
     fastbootAppConfig: fastbootConfig,

--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -1,4 +1,4 @@
-var Funnel    = require('broccoli-funnel');
+var Funnel = require('broccoli-funnel');
 var Plugin = require('broccoli-plugin');
 var defaults = require('lodash.defaults');
 
@@ -17,19 +17,23 @@ function EmptyTree(inputNodes, options) {
 EmptyTree.prototype.build = function() { };
 
 function FastBootBuild(options) {
-  this.assetMapPath = options.assetMapPath || 'assets/assetMap.json';
   this.project = options.project;
+  var defaultAssetMapPath = 'assets/assetMap.json';
   var assetRev = this.project.addons.filter(function(addon) {
     return addon.name === 'broccoli-asset-rev';
   })[0];
 
-  if (assetRev) {
-    if (assetRev.options && assetRev.options.assetMapPath) {
+  if (assetRev && assetRev.options) {
+    if (assetRev.options.assetMapPath) {
       this.assetMapPath = assetRev.options.assetMapPath;
+    }
+
+    if (assetRev.options.fingerprintAssetMap) {
+      defaultAssetMapPath = 'assets/assetMap-*.json'
     }
   }
 
-  this.assetMapPath = this.assetMapPath || 'assets/assetMap.json';
+  this.assetMapPath = this.assetMapPath || options.assetMapPath || defaultAssetMapPath;
   this.ui = options.ui;
   this.options = options;
   this.app = options.app;

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -98,13 +98,17 @@ FastBootConfig.prototype.buildDependencies = function() {
 };
 
 FastBootConfig.prototype.readAssetManifest = function() {
+  var ui = this.ui;
   var assetMapPath = path.join(this.inputPaths[0], 'fastbootAssetMap.json');
+  var assetMapEnabled = this.assetMapEnabled;
 
   try {
     var assetMap = JSON.parse(fs.readFileSync(assetMapPath));
     return assetMap;
   } catch (e) {
-    // No asset map was found, proceed as usual
+    if (this.assetMapEnabled) {
+      ui.writeLine(fmt("fastbootAssetMap.json not found at: %s", assetMapPath), ui.WARNING);
+    }
   }
 };
 


### PR DESCRIPTION
[broccoli-asset-rev](https://github.com/rickharrison/broccoli-asset-rev) has the option to fingerprint your asset map file.

This PR adds support for that scenario.

I'm not happy about using the wild card, but I don't think a `RegExp` will work there.