### PR TITLE
Only start app once, call fastboot.reload

### DIFF
--- a/index.js
+++ b/index.js
@@ -139,6 +139,10 @@ module.exports = {
     return fastbootBuild.toTree();
   },
 
+  outputReady: function() {
+    this.emit('outputReady');
+  },
+
   postBuild: function() {
     this.emit('postBuild');
   },
@@ -154,5 +158,4 @@ module.exports = {
 
     return checker.for('ember', 'bower');
   },
-
 };

--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -13,6 +13,7 @@ module.exports = CoreObject.extend({
   exec,
   http,
   httpServer: null,
+  fastboot: null,
   nextSocketId: 0,
   require,
   restartAgain: false,
@@ -21,54 +22,61 @@ module.exports = CoreObject.extend({
 
   run(options) {
     debug('run');
-    const restart = () => this.restart(options);
-    this.addon.on('postBuild', restart);
+    const ready = () => this.outputReady(options);
+    this.addon.on('outputReady', ready);
   },
 
   start(options) {
     debug('start');
-    this.ui.writeLine('Installing FastBoot npm dependencies');
 
-    return this.exec('npm install', { cwd: options.outputPath })
-      .then(() => {
-        const middleware = this.require('fastboot-express-middleware')(options.outputPath);
-        const express = this.require('express');
-        const app = express();
-        app.use(require('compression')());
+    const fastbootMiddleware = this.require('fastboot-express-middleware');
+    const FastBoot = this.require('fastboot');
+    const express = this.require('express');
 
-        if (options.serveAssets) {
-          app.get('/', middleware);
-          app.use(express.static(options.assetsPath));
-        }
-        app.get('/*', middleware);
-        app.use((req, res) => res.sendStatus(404));
+    this.fastboot = new FastBoot({
+      distPath: options.outputPath
+    });
 
-        this.httpServer = this.http.createServer(app);
+    const middleware = fastbootMiddleware({
+      outputPath: options.outputPath,
+      fastboot: this.fastboot
+    });
 
-        // Track open sockets for fast restart
-        this.httpServer.on('connection', (socket) => {
-          const socketId = this.nextSocketId++;
-          debug(`open socket ${socketId}`);
-          this.sockets[socketId] = socket;
-          socket.on('close', () => {
-            debug(`close socket ${socketId}`);
-            delete this.sockets[socketId];
-          });
-        });
+    const app = express();
+    app.use(require('compression')());
 
-        return new RSVP.Promise((resolve, reject) => {
-          this.httpServer.listen(options.port, options.host, (err) => {
-            if (err) { return reject(err); }
-            const o = this.httpServer.address();
-            const port = o.port;
-            const family = o.family;
-            let host = o.address;
-            if (family === 'IPv6') { host = `[${host}]`; }
-            this.ui.writeLine(`Ember FastBoot running at http://${host}:${port}`);
-            resolve();
-          });
-        });
+    if (options.serveAssets) {
+      app.get('/', middleware);
+      app.use(express.static(options.assetsPath));
+    }
+    app.get('/*', middleware);
+    app.use((req, res) => res.sendStatus(404));
+
+    this.httpServer = this.http.createServer(app);
+
+    // Track open sockets for fast restart
+    this.httpServer.on('connection', (socket) => {
+      const socketId = this.nextSocketId++;
+      debug(`open socket ${socketId}`);
+      this.sockets[socketId] = socket;
+      socket.on('close', () => {
+        debug(`close socket ${socketId}`);
+        delete this.sockets[socketId];
       });
+    });
+
+    return new RSVP.Promise((resolve, reject) => {
+      this.httpServer.listen(options.port, options.host, (err) => {
+        if (err) { return reject(err); }
+        const o = this.httpServer.address();
+        const port = o.port;
+        const family = o.family;
+        let host = o.address;
+        if (family === 'IPv6') { host = `[${host}]`; }
+        this.ui.writeLine(`Ember FastBoot running at http://${host}:${port}`);
+        resolve();
+      });
+    });
   },
 
   stop() {
@@ -89,39 +97,18 @@ module.exports = CoreObject.extend({
     });
   },
 
-  restart(options) {
-    if (this.restartPromise) {
-      debug('schedule immediate restart');
-      this.restartAgain = true;
-      return;
-    }
-    debug('restart');
-    this.restartPromise = this.stop()
-      .then(() => this.clearRequireCache(options.outputPath))
-      .then(() => this.start(options))
-      .catch(e => this.printError(e))
-      .finally(() => {
-        this.restartPromise = null;
-        if (this.restartAgain) {
-          debug('restart again');
-          this.restartAgain = false;
-          this.restart(options);
-        }
-      });
-    return this.restartPromise;
+  restart() {
+    return this.fastboot.reload();
   },
 
-  clearRequireCache: function (serverRoot) {
-    debug('clearRequireCache');
-    let absoluteServerRoot = path.resolve(serverRoot);
-    if (absoluteServerRoot.slice(-1) !== path.sep) {
-      absoluteServerRoot += path.sep;
+  outputReady(options) {
+    if (this.fastboot) {
+      this.ui.writeLine(`Reloading FastBoot`);
+      return this.restart();
+    } else {
+      return this.start(options)
+        .catch(e => this.printError(e));
     }
-    Object.keys(require.cache).forEach(function (key) {
-      if (key.indexOf(absoluteServerRoot) === 0) {
-        delete require.cache[key];
-      }
-    });
   },
 
   /*

--- a/test/asset-rewriting-test.js
+++ b/test/asset-rewriting-test.js
@@ -5,7 +5,7 @@ var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 var glob = require('glob');
 
 describe('rewriting HTML', function() {
-  this.timeout(300000);
+  this.timeout(400000);
 
   var app;
 

--- a/test/async-content-test.js
+++ b/test/async-content-test.js
@@ -6,7 +6,7 @@ var request = require('request');
 var get = RSVP.denodeify(request);
 
 describe('async content via deferred content', function() {
-  this.timeout(300000);
+  this.timeout(400000);
 
   var app;
 


### PR DESCRIPTION
Remove `npm install` from watch cycle

As @ef4 pointed out, it's not required, as the node_modules in the root
of the project will be used

Need to update tests
