### PR TITLE
In Ember 2.7+ assets should be served from a rootURL-prefixed path

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -43,7 +43,8 @@ module.exports = function(addon) {
       const ServerTask = this.ServerTask;
       const serverTask = new ServerTask({
         ui: this.ui,
-        addon: addon
+        addon: addon,
+        project: this.project
       });
       return serverTask.run(options);
     },

--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -36,8 +36,16 @@ module.exports = CoreObject.extend({
         app.use(require('compression')());
 
         if (options.serveAssets) {
+          const projectConfig = this.project.config(options.environment);
+
           app.get('/', middleware);
-          app.use(express.static(options.assetsPath));
+
+          // in Ember 2.7+ assets should be served from a rootURL-prefixed path
+          if(projectConfig.hasOwnProperty('rootURL') && !projectConfig.hasOwnProperty('baseURL')) {
+            app.use(projectConfig.rootURL, express.static(options.assetsPath));
+          } else {
+            app.use(express.static(options.assetsPath));
+          }
         }
         app.get('/*', middleware);
         app.use((req, res) => res.sendStatus(404));

--- a/test/lib-tasks-fastboot-server-test.js
+++ b/test/lib-tasks-fastboot-server-test.js
@@ -36,6 +36,7 @@ function MockAddon() {
 MockAddon.prototype = Object.create(EventEmitter.prototype);
 
 const mockUI = { writeLine() {} };
+const mockProject = { config() {} };
 
 describe('fastboot server task', function() {
   let options, task;
@@ -44,7 +45,8 @@ describe('fastboot server task', function() {
     this.sinon = sinon.sandbox.create();
     task = new FastbootServerTask({
       ui: mockUI,
-      addon: addon
+      addon: addon,
+      project: mockProject
     });
     options = new CommandOptions();
   });
@@ -154,7 +156,7 @@ describe('fastboot server task', function() {
   });
 
   describe('start', function() {
-    let createServerStub, execStub, mockServer, requireSpy, useStub;
+    let createServerStub, execStub, mockServer, requireSpy, useStub, mockProject;
     const mockApp = { get() {}, use() {} };
     const mockExpress = () => mockApp;
     const mockExpressStatic = {};
@@ -189,10 +191,25 @@ describe('fastboot server task', function() {
     });
 
     it('uses express.static when serve-assets=true', function() {
+      const projectConfigStug = this.sinon.stub(task.project, 'config').returns({
+        baseURL: '/',
+        rootURL: '/app'
+      });
       options = new CommandOptions({ serveAssets: true });
       return task.start(options)
         .then(() => {
           expect(useStub.calledWith(mockExpressStatic)).to.equal(true);
+        });
+    });
+
+    it('uses express.static with rootURL prefixed path when serve-assets=true and baseURL is not set', function() {
+      const projectConfigStug = this.sinon.stub(task.project, 'config').returns({
+        rootURL: '/app'
+      });
+      options = new CommandOptions({ serveAssets: true });
+      return task.start(options)
+        .then(() => {
+          expect(useStub.calledWith('/app', mockExpressStatic)).to.equal(true);
         });
     });
 


### PR DESCRIPTION
In Ember 2.7+, using the baseURL has been deprecated (see http://emberjs.com/blog/2016/04/28/baseURL.html) and the assets should be served from a rootURL prefixed path.
