### PR TITLE
Update the version of Ember that doesn't need the dom helper patches.

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = {
 
     var trees = [defaultTree];
 
-    if (emberVersion.lt('2.9.0-alpha.1')) {
+    if (emberVersion.lt('2.10.0-alpha.1')) {
       trees.push(this.treeGenerator(path.resolve(this.root, 'app-lt-2-9')));
     }
 


### PR DESCRIPTION
Since glimmer2 is not going to be shipped with Ember 2.9, we need the dom helper patches for rendering apps on server side.