### PR TITLE
WIP: Register fastboot and ember-cli-fastboot versions

### DIFF
--- a/addon/versions.js
+++ b/addon/versions.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+if (Ember.libraries) {
+  Ember.libraries.register('FastBoot', 'FASTBOOT_VERSION');
+  Ember.libraries.register('Ember CLI FastBoot', 'EMBER_CLI_FASTBOOT_VERSION');
+}

--- a/app/initializers/fastboot/ajax.js
+++ b/app/initializers/fastboot/ajax.js
@@ -1,5 +1,6 @@
 /* globals najax */
 import Ember from 'ember';
+import 'ember-cli-fastboot/versions';
 
 const { get } = Ember;
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.0",
+    "broccoli-string-replace": "^0.1.1",
     "chai": "^2.2.0",
     "chai-fs": "peterkc/chai-fs#31deec5232297e2887a2ffb39b9081364c8e78e1",
     "chalk": "^1.1.1",
@@ -44,6 +45,7 @@
     "exists-sync": "0.0.3",
     "fs-extra": "^0.24.0",
     "fs-promise": "^0.3.1",
+    "get-git-info": "^1.0.0",
     "glob": "^7.0.0",
     "loader.js": "^4.0.1",
     "mocha": "^2.2.4",


### PR DESCRIPTION
Allows fastboot server to print out current versions on app boot