### PR TITLE
Static isFastBoot prop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ cache:
 before_install:
   - "npm config set spin false"
   - "npm install -g npm@^2"
+  - npm install phantomjs-prebuilt
+  - node_modules/phantomjs-prebuilt/bin/phantomjs --version
 
 install:
   - npm install -g bower

--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -60,7 +60,7 @@ const Shoebox = Ember.Object.extend({
   }
 });
 
-export default Ember.Service.extend({
+const FastBootService = Ember.Service.extend({
   cookies: deprecatingAlias('request.cookies', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
   headers: deprecatingAlias('request.headers', { id: 'fastboot.headers-to-request', until: '0.9.9' }),
 
@@ -85,12 +85,8 @@ export default Ember.Service.extend({
   metadata: readOnly('_fastbootInfo.metadata'),
 
   request: computed(function() {
-    if (!get(this, 'isFastBoot')) return null;
+    if (!this.isFastBoot) return null;
     return RequestObject.create({ request: get(this, '_fastbootInfo.request') });
-  }),
-
-  isFastBoot: computed(function() {
-    return typeof FastBoot !== 'undefined';
   }),
 
   deferRendering(promise) {
@@ -98,3 +94,11 @@ export default Ember.Service.extend({
     this._fastbootInfo.deferRendering(promise);
   }
 });
+
+Object.defineProperty(FastBootService.proto(), 'isFastBoot', {
+  writable: false,
+  enumerable: true,
+  value: typeof FastBoot !== 'undefined'
+});
+
+export default FastBootService;

--- a/tests/unit/services/fastboot-test.js
+++ b/tests/unit/services/fastboot-test.js
@@ -3,8 +3,17 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('service:fastboot', 'Unit | Service | fastboot in the browser', {});
 
 test('isFastBoot', function(assert) {
+  assert.expect(3);
+
   let service = this.subject();
+  assert.equal(service.isFastBoot, false, `it should be false`);
   assert.equal(service.get('isFastBoot'), false, `it should be false`);
+
+  try {
+    service.isFastBoot = true;
+  } catch(e) {
+    assert.ok(true, 'throws since isFastBoot is not writable');
+  }
 });
 
 test('request', function(assert) {


### PR DESCRIPTION
`isFastBoot` doesn't change over the lifetime of the app, doesn't need to be recomputed so doesn't need to be a computed.  Made it also not writable as part of this change.

This is to avoid being trolled #291 

* [x] fix test

/cc @danmcclain 