### PR TITLE
remove ember-cli-content-security-policy

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "ember-cli": "2.10.0",
     "ember-cli-addon-tests": "^0.3.0",
     "ember-cli-app-version": "^2.0.0",
-    "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.3.0",
     "ember-cli-htmlbars": "^1.0.10",
     "ember-cli-htmlbars-inline-precompile": "^0.3.3",


### PR DESCRIPTION
I don't think it's necessary for an addon