### PR TITLE
Create an array of app & vendor files for fastboot manifest

### DIFF
--- a/lib/broccoli/fastboot-build.js
+++ b/lib/broccoli/fastboot-build.js
@@ -24,7 +24,7 @@ function FastBootBuild(options) {
   })[0];
 
   if (assetRev && assetRev.options) {
-    this.assetMapEnabled = !!(assetRev.options.enabled && assetRev.options.assetMapPath);
+    this.assetMapEnabled = !!(assetRev.options.enabled && assetRev.options.generateAssetMap);
 
     if (assetRev.options.assetMapPath) {
       this.assetMapPath = assetRev.options.assetMapPath;

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -5,7 +5,7 @@ var md5Hex = require('md5-hex');
 var path   = require('path');
 var Plugin = require('broccoli-plugin');
 
-var LATEST_SCHEMA_VERSION = 1;
+var LATEST_SCHEMA_VERSION = 2;
 
 function FastBootConfig(inputNode, options) {
   Plugin.call(this, [inputNode], {
@@ -14,6 +14,7 @@ function FastBootConfig(inputNode, options) {
 
   this.project = options.project;
   this.name = options.name;
+  this.assetMapEnabled = options.assetMapEnabled;
   this.ui = options.ui;
   this.fastbootAppConfig = options.fastbootAppConfig;
   this.outputPaths = options.outputPaths;
@@ -121,8 +122,8 @@ FastBootConfig.prototype.buildManifest = function() {
   var vendorFile = 'fastboot/' + vendorFileName + '.js';
 
   var manifest = {
-    appFile: appFile,
-    vendorFile: vendorFile,
+    appFiles: [appFile],
+    vendorFiles: [vendorFile],
     htmlFile: this.htmlFile
   };
 
@@ -139,10 +140,20 @@ FastBootConfig.prototype.buildManifest = function() {
       assets[rewrittenKey] = assetToFastboot(rewrittenAssets.assets[key]);
     }
 
-    ['appFile', 'vendorFile'].forEach(function(file) {
-      // Update package.json with the fingerprinted file.
-      manifest[file] = assets[manifest[file]];
+    // update the vendor file with the fingerprinted file
+    var rewrittenVendorFiles = [];
+    manifest['vendorFiles'].forEach(function(file) {
+      rewrittenVendorFiles.push(assets[file]);
     });
+    manifest['vendorFiles'] = rewrittenVendorFiles;
+
+    // update the app files array with fingerprinted files
+    var rewrittenAppFiles = [];
+    manifest['appFiles'].forEach(function(file) {
+      rewrittenAppFiles.push(assets[file]);
+    });
+    manifest['appFiles'] = rewrittenAppFiles;
+
   }
 
   this.manifest = manifest;

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -45,7 +45,7 @@ describe('generating package.json', function() {
     it("contains a schema version", function() {
       var pkg = fs.readJsonSync(app.filePath('/dist/package.json'));
 
-      expect(pkg.fastboot.schemaVersion).to.deep.equal(1);
+      expect(pkg.fastboot.schemaVersion).to.deep.equal(2);
     });
 
     it("contains a whitelist of allowed module names", function() {
@@ -64,9 +64,9 @@ describe('generating package.json', function() {
       var pkg = fs.readJsonSync(app.filePath('/dist/package.json'));
 
       expect(pkg.fastboot.manifest).to.deep.equal({
-        appFile: 'fastboot/module-whitelist.js',
+        appFiles: ['fastboot/module-whitelist.js'],
         htmlFile: 'index.html',
-        vendorFile: 'fastboot/vendor.js'
+        vendorFiles: ['fastboot/vendor.js']
       });
     });
 
@@ -114,9 +114,13 @@ describe('generating package.json', function() {
 
       var manifest = pkg.fastboot.manifest;
 
-      expect(p(manifest.appFile)).to.be.a.file();
+      manifest.appFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
       expect(p(manifest.htmlFile)).to.be.a.file();
-      expect(p(manifest.vendorFile)).to.be.a.file();
+      manifest.vendorFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
     });
   });
 
@@ -141,9 +145,13 @@ describe('generating package.json', function() {
       var pkg = fs.readJsonSync(customApp.filePath('/dist/package.json'));
       var manifest = pkg.fastboot.manifest;
 
-      expect(p(manifest.appFile)).to.be.a.file();
+      manifest.appFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
       expect(p(manifest.htmlFile)).to.be.a.file();
-      expect(p(manifest.vendorFile)).to.be.a.file();
+      manifest.vendorFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
     });
 
   });
@@ -168,9 +176,13 @@ describe('generating package.json', function() {
       var pkg = fs.readJsonSync(customApp.filePath('/dist/package.json'));
       var manifest = pkg.fastboot.manifest;
 
-      expect(p(manifest.appFile)).to.be.a.file();
+      manifest.appFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
       expect(p(manifest.htmlFile)).to.be.a.file();
-      expect(p(manifest.vendorFile)).to.be.a.file();
+      manifest.vendorFiles.forEach(function(file) {
+        expect(p(file)).to.be.a.file();
+      });
     });
 
   });


### PR DESCRIPTION
This PR is to address a [usecase](https://github.com/ember-fastboot/ember-cli-fastboot/issues/270) where an app may want to load other assets after the vendor asset is loaded and before the app asset is loaded in the sandbox. Primarily for example, if we want to load i18n translations file, lazy engine assets. Making the appFiles an array allows other addons that will run after ember-cli-fastboot to update package.json with the order.

It does so by making `appFile` an array in FastBoot manifest. Any addon (running after ember-cli-fastboot) now has a low level primitive to update the `appFiles` array with the order in which they would like load the assets in sandbox.

Also found a bug with fingerprinting assets in FastBoot. We should be using `generateAssetMap` option of `broccoli-asset-rev` to see if assetMap.json is generated.

**Note**: This was discussed a few weeks ago in FastBoot meeting and we decided to provide a low level primitive for advanced addons to override the package.json manifest with the order of assets they would like to load.

Corresponding FastBoot [PR](https://github.com/ember-fastboot/fastboot/pull/105)

TODO:

- [x] Once FastBoot [PR](https://github.com/ember-fastboot/fastboot/pull/105) lands release it and update fastboot-express-middleware
- [x] Fix tests once FastBoot [PR](https://github.com/ember-fastboot/fastboot/pull/105) lands and is released
- [x] Come up with a schema versioning after discussing with @rwjblue 