### PR TITLE
Allow najax errors to bubble up to the error callback

### DIFF
--- a/app/initializers/fastboot/ajax.js
+++ b/app/initializers/fastboot/ajax.js
@@ -19,7 +19,11 @@ var nodeAjax = function(options) {
   }
 
   if (najax) {
-    najax(options);
+    najax(options).fail(function(jqXHR, statusText, e) {
+      if('error' in options) {
+        options.error(jqXHR, statusText, e);
+      }
+    });
   } else {
     throw new Error('najax does not seem to be defined in your app. Did you override it via `addOrOverrideSandboxGlobals` in the fastboot server?');
   }


### PR DESCRIPTION
We are seeing that errors, caused from najax being unable to parse json in the response, are causing the fastboot server to crash.  This can be reproduced when an api returns an html response when the expectation is json.  Examples:  Gateway Errors, Redirects, 404 pages.

This catches the error, and forwards it to the options.error function which najax does not even use currently.