### PR TITLE
Introduce schema version in FastBoot package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 ---
 language: node_js
 node_js:
-  - "5"
   - "4"
+  - "stable"
 
 env:
   - CXX=g++-4.8 WORKER_COUNT=2

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -5,6 +5,8 @@ var md5Hex = require('md5-hex');
 var path   = require('path');
 var Plugin = require('broccoli-plugin');
 
+var LATEST_SCHEMA_VERSION = 1;
+
 function FastBootConfig(inputNode, options) {
   Plugin.call(this, [inputNode], {
     annotation: "Generate: FastBoot package.json"
@@ -157,6 +159,7 @@ FastBootConfig.prototype.toJSONString = function() {
     dependencies: this.dependencies,
     fastboot: {
       moduleWhitelist: this.moduleWhitelist,
+      schemaVersion: LATEST_SCHEMA_VERSION,
       manifest: this.manifest,
       hostWhitelist: this.normalizeHostWhitelist(),
       appConfig: this.appConfig

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -42,6 +42,12 @@ describe('generating package.json', function() {
       });
     });
 
+    it("contains a schema version", function() {
+      var pkg = fs.readJsonSync(app.filePath('/dist/package.json'));
+
+      expect(pkg.fastboot.schemaVersion).to.deep.equal(1);
+    });
+
     it("contains a whitelist of allowed module names", function() {
       var pkg = fs.readJsonSync(app.filePath('/dist/package.json'));
 


### PR DESCRIPTION
## Motivation
`ember-cli-fastboot` publishes a package.json in the dist directory of any ember app that is used by the `fastboot` library to read and load app/vendor files, serve the required html file etc. The `fastboot` micro library has highly dependent on the output format of the package.json. If there is a change in the format of package.json, `fastboot` library needs to be compatible with it. In order to introduce the compatibility, the package.json will contain a `schemaVersion` field. This field will be updated everytime there is an incompatible change from `ember-cli-fastboot`. If apps, are using `fastboot` version in production that is incompatible with `ember-cli-fastboot`, we will be throwing **an error** when the fastboot server comes up. This will allow people to be aware of the incompatible change and upgrade their versions for smooth running.

## Description of changes
The changes in this PR add a field called `schemaVersion` under the `fastboot` namespace. The version starting in here is `1` and **will need** to be bumped everytime an incompatible change in package.json is introduced. An example of such a change is https://github.com/ember-fastboot/ember-cli-fastboot/pull/325 .

`fastboot` library changes are [here](https://github.com/ember-fastboot/fastboot/pull/114)

## Future
Everytime the schema version is updated in `ember-cli-fastboot`, it will also need to be updated in the `fastboot` library. See this PR for the change: https://github.com/ember-fastboot/fastboot/pull/114

cc: @rwjblue @tomdale 