### PR TITLE
process.env.FASTBOOT_DISABLED to disable fastboot build

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,21 @@ Prototype extensions do not currently work across node "realms."  Fastboot
 applications operate in two realms, a normal node environment and a [virtual machine](https://nodejs.org/api/vm.html).  Passing objects that originated from the normal realm will not contain the extension methods
 inside of the sandbox environment. For this reason, it's encouraged to [disable prototype extensions](https://guides.emberjs.com/v2.4.0/configuring-ember/disabling-prototype-extensions/).
 
+### Double build times and no incremental builds
+
+Due to limitations in Ember CLI, builds take twice as long to generate the
+second set of FastBoot assets. This also means incremental builds with
+live reload don't work either. This aims to be resolved by FastBoot 1.0.
+In the mean time, we introduce a short-circuit evironment flag to not do
+a FastBoot build:
+
+```
+FASTBOOT_DISABLED=true ember build
+```
+
+This is useful to keep your existing workflow while in development, while
+still being able to deploy FastBoot. This flag will be removed in FastBoot
+1.0.
 
 ## Troubleshooting
 

--- a/index.js
+++ b/index.js
@@ -112,9 +112,12 @@ module.exports = {
   /**
    * After the entire Broccoli tree has been built for the `dist` directory,
    * adds the `fastboot-config.json` file to the root.
+   *
+   * FASTBOOT_DISABLED is a pre 1.0 power user flag to
+   * disable the fastboot build while retaining the fastboot service.
    */
   postprocessTree: function(type, tree) {
-    if (type === 'all') {
+    if (type === 'all' && !process.env.FASTBOOT_DISABLED) {
       var fastbootTree = this.buildFastBootTree();
 
       // Merge the package.json with the existing tree
@@ -148,7 +151,7 @@ module.exports = {
     if (emberVersionChecker.version) {
       return emberVersionChecker;
     }
-    
+
     return checker.for('ember', 'bower');
   },
 


### PR DESCRIPTION
This would be a pre 1.0 power user flag to disable the fastboot build while retaining the fastboot service. Use case is large legacy apps that already take forever to build. Developing locally would like the option to disable fastboot while CI does the fastboot builds. I tried blacklisting the addon, but then I got `Error: Attempting to inject an unknown injection: 'service:fastboot'` on CI because the fastboot service was gone.

I brought this up in slack and there was at least one other user with a fork of fastboot doing this check as well as me.