### PR TITLE
Add hooks to fastboot server task

### DIFF
--- a/lib/tasks/fastboot-server.js
+++ b/lib/tasks/fastboot-server.js
@@ -8,7 +8,7 @@ const http = require('http');
 const path = require('path');
 const parseStackTrace = require('../utilities/parse-stack-trace');
 
-module.exports = CoreObject.extend({
+let FastbootServerTask = CoreObject.extend({
 
   exec,
   http,
@@ -36,6 +36,7 @@ module.exports = CoreObject.extend({
         const app = express();
         app.use(require('compression')());
 
+        FastbootServerTask.invokeOn('start', app);
         if (options.serveAssets) {
           app.get('/', middleware);
           app.use(express.static(options.assetsPath));
@@ -163,3 +164,15 @@ module.exports = CoreObject.extend({
     this.ui.writeError(e);
   }
 });
+
+FastbootServerTask._hooks = {start: []};
+FastbootServerTask.on = function(type, hook) {
+  this._hooks[type].push(hook);
+}
+FastbootServerTask.invokeOn = function (type, app) {
+  for (let hook of this._hooks[type]) {
+    hook(app);
+  }
+}
+
+module.exports = FastbootServerTask;


### PR DESCRIPTION
Not sure if this is the best way to solve, but we'd like to add route handlers to the express server started by fastboot. One concrete usecase is `http-proxy` to proxy api requests to real backend, other usecase is running mirage as express middleware.

Right now i'm using it by adding `app/instance-initializers/fastboot/start-proxy.js`. In there i do this:

```es6
function proxy(app) {
  var httpProxy = FastBoot.require('http-proxy');
   ...
   var proxy = httpProxy.createProxyServer(proxyOptions);
   ...
   app.use("/api", function(req, res, next) {
      ...
      proxy.web(req, res, {target: proxyTarget});
   })
}

let FastbootServerTask = FastBoot.require('ember-cli-fastboot/lib/tasks/fastboot-server');
FastbootServerTask.on('start', function (app) {
   proxy(app);
});
...
```



