### PR TITLE
Fix server never getting started when using --no-build flag

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -6,7 +6,6 @@ const ServerTask = require('../tasks/fastboot-server');
 const SilentError = require('silent-error');
 
 const blockForever = () => (new RSVP.Promise(() => {}));
-const noop = function() { };
 
 module.exports = function(addon) {
   return {
@@ -31,11 +30,12 @@ module.exports = function(addon) {
     run(options) {
       const runBuild = () => this.runBuild(options);
       const runServer = () => this.runServer(options);
+      const startServer = (serverTask) => this.startServer(serverTask, options);
       const blockForever = this.blockForever;
 
       return this.checkPort(options)
         .then(runServer) // starts on postBuild SIGHUP
-        .then(options.build ? runBuild : noop)
+        .then(options.build ? runBuild : startServer)
         .then(blockForever);
     },
 
@@ -45,7 +45,12 @@ module.exports = function(addon) {
         ui: this.ui,
         addon: addon
       });
-      return serverTask.run(options);
+      serverTask.run(options);
+      return serverTask;
+    },
+
+    startServer(serverTask, options) {
+      serverTask.start(options);
     },
 
     runBuild(options) {

--- a/test/lib-commands-fastboot-test.js
+++ b/test/lib-commands-fastboot-test.js
@@ -25,10 +25,11 @@ describe('fastboot command', function() {
         blockForever: RSVP.resolve,
         checkPort: RSVP.resolve,
         runServer: RSVP.resolve,
+        startServer: RSVP.resolve,
         tasks: {
           Build: CoreObject.extend({ run() { buildRunCalled = true; } }),
           BuildWatch: CoreObject.extend({ run() { buildWatchRunCalled = true; } }),
-        },
+        }
       });
     });
 
@@ -53,6 +54,30 @@ describe('fastboot command', function() {
       return command.run(options).then(() => {
         expect(buildRunCalled).to.equal(false);
         expect(buildWatchRunCalled).to.equal(false);
+      });
+    });
+  });
+
+  describe('run server', function() {
+    let command, serverStartCalled;
+
+    beforeEach(function() {
+      serverStartCalled = false;
+      command = new FastbootCommand({
+        blockForever: RSVP.resolve,
+        checkPort: RSVP.resolve,
+        runBuild: RSVP.resolve,
+        ServerTask: CoreObject.extend({
+          run() { },
+          start() { serverStartCalled = true; }
+        })
+      });
+    });
+
+    it('immediately starts server when build=false', function() {
+      const options = new CommandOptions({ build: false });
+      return command.run(options).then(() => {
+        expect(serverStartCalled).to.equal(true);
       });
     });
   });


### PR DESCRIPTION
When running `ember fastboot --no-build` (which is mentioned in the README for a fast debug mode) the server is never started, as it is waiting endlessly for the `postBuild` event, which is never fired when skipping the build step.

This should fix it, immediately calling `start` after `run` when `options.build` is false.