### PR TITLE
Bump fastboot-express-middleware version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-babel": "^5.1.7",
     "ember-cli-version-checker": "^1.1.6",
     "express": "^4.8.5",
-    "fastboot-express-middleware": "1.0.0-rc.3",
+    "fastboot-express-middleware": "1.0.0-rc.7",
     "fastboot-filter-initializers": "0.0.2",
     "lodash.defaults": "^4.0.1",
     "lodash.uniq": "^4.2.0",

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -56,8 +56,8 @@ describe('simple acceptance', function() {
     return request('http://localhost:49741/boom')
       .then(function(response) {
         expect(response.statusCode).to.equal(500);
-        expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
-        expect(response.body).to.equal("Internal Server Error");
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.body).to.equal("BOOM\n");
       });
   });
 


### PR DESCRIPTION
Needed to fix one test. The failing test was because when we there is an error from fastboot and it is not UnrecognizedUrl, we don't close the response but mark it to 500 and call the next middleware. Express then sets the correct response and content type.

cc: @rwjblue 