### PR TITLE
Make isFastBoot writeable (again)

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -63,6 +63,7 @@ const Shoebox = Ember.Object.extend({
 const FastBootService = Ember.Service.extend({
   cookies: deprecatingAlias('request.cookies', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
   headers: deprecatingAlias('request.headers', { id: 'fastboot.headers-to-request', until: '0.9.9' }),
+  isFastBoot: typeof FastBoot !== 'undefined',
 
   init() {
     this._super(...arguments);
@@ -93,12 +94,6 @@ const FastBootService = Ember.Service.extend({
     Ember.assert('deferRendering requires a promise or thennable object', typeof promise.then === 'function');
     this._fastbootInfo.deferRendering(promise);
   }
-});
-
-Object.defineProperty(FastBootService.proto(), 'isFastBoot', {
-  writable: false,
-  enumerable: true,
-  value: typeof FastBoot !== 'undefined'
 });
 
 export default FastBootService;

--- a/tests/unit/services/fastboot-test.js
+++ b/tests/unit/services/fastboot-test.js
@@ -3,17 +3,9 @@ import { moduleFor, test } from 'ember-qunit';
 moduleFor('service:fastboot', 'Unit | Service | fastboot in the browser', {});
 
 test('isFastBoot', function(assert) {
-  assert.expect(3);
-
   let service = this.subject();
   assert.equal(service.isFastBoot, false, `it should be false`);
   assert.equal(service.get('isFastBoot'), false, `it should be false`);
-
-  try {
-    service.isFastBoot = true;
-  } catch(e) {
-    assert.ok(true, 'throws since isFastBoot is not writable');
-  }
 });
 
 test('request', function(assert) {


### PR DESCRIPTION
Discussion: #303

There is a need to allow this prop to be stubbed, currently that is not easy and would involve stubbing `self.Fastboot` which isn't great since it cannot be reset.

/cc @bcardarella 