### PR TITLE
Unify fastboot serving with ember-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ ember install ember-cli-fastboot
 * `ember fastboot --serve-assets`
 * Visit your app at `http://localhost:3000`.
 
+**Note**: If your app is running ember-cli v2.12.0-beta.1+, you can just use `ember serve` instead of `ember fastboot --serve-assets`.
+
 You may be shocked to learn that minified code runs faster in Node than
 non-minified code, so you will probably want to run the production
 environment build for anything "serious."
@@ -381,7 +383,7 @@ present.
 
 ### Prototype extensions
 
-Prototype extensions do not currently work across node "realms."  Fastboot 
+Prototype extensions do not currently work across node "realms."  Fastboot
 applications operate in two realms, a normal node environment and a [virtual machine](https://nodejs.org/api/vm.html).  Passing objects that originated from the normal realm will not contain the extension methods
 inside of the sandbox environment. For this reason, it's encouraged to [disable prototype extensions](https://guides.emberjs.com/v2.4.0/configuring-ember/disabling-prototype-extensions/).
 

--- a/lib/commands/fastboot-build.js
+++ b/lib/commands/fastboot-build.js
@@ -20,7 +20,7 @@ module.exports = {
       project: this.project
     });
 
-    deprecate("Use of ember fastboot:build is deprecated. Please use ember build instead.");
+    deprecate('Use of ember fastboot:build is deprecated. Please use ember build instead.');
 
     return buildTask.run(options);
   },

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -4,6 +4,7 @@ const RSVP = require('rsvp');
 const getPort = RSVP.denodeify(require('portfinder').getPort);
 const ServerTask = require('../tasks/fastboot-server');
 const SilentError = require('silent-error');
+const VersionChecker = require('ember-cli-version-checker');
 
 const blockForever = () => (new RSVP.Promise(() => {}));
 
@@ -28,12 +29,14 @@ module.exports = function(addon) {
     ServerTask,
 
     run(options) {
+      const printDeprecations = () => this.printDeprecations(options);
       const runBuild = () => this.runBuild(options);
       const runServer = () => this.runServer(options);
       const startServer = (serverTask) => this.startServer(serverTask, options);
       const blockForever = this.blockForever;
 
       return this.checkPort(options)
+        .then(printDeprecations)
         .then(runServer) // starts on postBuild SIGHUP
         .then(options.build ? runBuild : startServer)
         .then(blockForever);
@@ -72,6 +75,17 @@ module.exports = function(addon) {
           }
           options.port = foundPort;
         });
+    },
+
+    printDeprecations(options) {
+      var checker = new VersionChecker(this);
+      var dep = checker.for('ember-cli', 'npm');
+
+      if (dep.satisfies('>= 2.12.0-beta.1')) {
+        this.ui.writeDeprecateLine('`ember fastboot --serve-assets` is deprecated. Please use `ember serve` to serve your fastboot assets.');
+      } else {
+        this.ui.writeWarnLine('`ember fastboot` will no longer work after FastBoot 1.0 is released.');
+      }
     },
 
   }

--- a/package.json
+++ b/package.json
@@ -23,12 +23,13 @@
     "broccoli-merge-trees": "^1.1.1",
     "broccoli-plugin": "^1.2.1",
     "broccoli-stew": "^1.2.0",
+    "chalk": "^1.1.3",
     "compression": "^1.6.2",
     "core-object": "^2.0.5",
     "debug": "^2.2.0",
     "ember-cli-babel": "^5.1.7",
     "ember-cli-eslint": "^3.0.2",
-    "ember-cli-version-checker": "^1.1.6",
+    "ember-cli-version-checker": "^1.2.0",
     "express": "^4.8.5",
     "fastboot-express-middleware": "1.0.0-rc.7",
     "fastboot-filter-initializers": "0.0.2",
@@ -77,6 +78,9 @@
     "configPath": "tests/dummy/config",
     "after": [
       "broccoli-asset-rev"
+    ],
+    "before": [
+      "broccoli-serve-files"
     ]
   }
 }

--- a/test/async-content-test.js
+++ b/test/async-content-test.js
@@ -8,31 +8,65 @@ var get = RSVP.denodeify(request);
 describe('async content via deferred content', function() {
   this.timeout(400000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
+    before(function() {
 
-    app = new AddonTestApp();
+      app = new AddonTestApp();
 
-    return app.create('async-content')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot',
-          additionalArguments: ['--serve-assets']
+      return app.create('async-content')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot',
+            additionalArguments: ['--serve-assets']
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('waits for async content when using `fastboot.deferRendering`', function() {
+      return get({
+        url: 'http://localhost:49741/'
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Async content: foo');
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('waits for async content when using `fastboot.deferRendering`', function() {
-    return get({
-      url: 'http://localhost:49741/'
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Async content: foo');
-      });
+    before(function() {
+
+      app = new AddonTestApp();
+
+      return app.create('async-content')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('waits for async content when using `fastboot.deferRendering`', function() {
+      return get({
+        url: 'http://localhost:49741/',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Async content: foo');
+        });
+    });
   });
 });

--- a/test/error-handler-test.js
+++ b/test/error-handler-test.js
@@ -1,33 +1,66 @@
-var expect           = require('chai').expect;
-var RSVP             = require('rsvp');
-var request          = RSVP.denodeify(require('request'));
+var expect = require('chai').expect;
+var RSVP = require('rsvp');
+var request = RSVP.denodeify(require('request'));
 
-var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 describe('error handler acceptance', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
-    app = new AddonTestApp();
+    before(function() {
+      app = new AddonTestApp();
 
-    return app.create('error-handler')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot'
+      return app.create('error-handler')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot'
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('visiting `/` does not result in an error', function() {
+      return request('http://localhost:49741/')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('visiting `/` does not result in an error', function() {
-    return request('http://localhost:49741/')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-      });
+    before(function() {
+      app = new AddonTestApp();
+
+      return app.create('error-handler')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('visiting `/` does not result in an error', function() {
+      return request({
+        url: 'http://localhost:49741/',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+        });
+    });
   });
 });

--- a/test/fastboot-location-config-test.js
+++ b/test/fastboot-location-config-test.js
@@ -8,6 +8,8 @@ var get = RSVP.denodeify(request);
 describe('FastBootLocation Configuration', function () {
   this.timeout(300000);
 
+  var app;
+
   before(function () {
     app = new AddonTestApp();
 

--- a/test/fastboot-location-test.js
+++ b/test/fastboot-location-test.js
@@ -8,6 +8,7 @@ var get = RSVP.denodeify(request);
 describe('FastBootLocation', function () {
   this.timeout(300000);
 
+  var app;
   before(function () {
     app = new AddonTestApp();
 

--- a/test/lib-commands-fastboot-test.js
+++ b/test/lib-commands-fastboot-test.js
@@ -23,6 +23,7 @@ describe('fastboot command', function() {
       buildRunCalled = buildWatchRunCalled = false;
       command = new FastbootCommand({
         blockForever: RSVP.resolve,
+        printDeprecations: RSVP.resolve,
         checkPort: RSVP.resolve,
         runServer: RSVP.resolve,
         startServer: RSVP.resolve,
@@ -65,6 +66,7 @@ describe('fastboot command', function() {
       serverStartCalled = false;
       command = new FastbootCommand({
         blockForever: RSVP.resolve,
+        printDeprecations: RSVP.resolve,
         checkPort: RSVP.resolve,
         runBuild: RSVP.resolve,
         ServerTask: CoreObject.extend({
@@ -89,6 +91,7 @@ describe('fastboot command', function() {
       isCalled = false;
       command = new FastbootCommand({
         blockForever: RSVP.resolve,
+        printDeprecations: RSVP.resolve,
         getPort: () => RSVP.resolve(1),
         runBuild: RSVP.resolve,
         ServerTask: CoreObject.extend({ run() { isCalled = true; } }),

--- a/test/lib-tasks-fastboot-server-test.js
+++ b/test/lib-tasks-fastboot-server-test.js
@@ -35,7 +35,11 @@ function MockAddon() {
 
 MockAddon.prototype = Object.create(EventEmitter.prototype);
 
-const mockUI = { writeLine() {} };
+const mockUI = {
+  writeLine: function() {},
+  writeDeprecateLine: function() {},
+  writeWarnLine: function() {}
+};
 
 describe('fastboot server task', function() {
   let options, task;

--- a/test/request-details-test.js
+++ b/test/request-details-test.js
@@ -8,89 +8,196 @@ var get = RSVP.denodeify(request);
 describe('request details', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
+    before(function() {
 
-    app = new AddonTestApp();
+      app = new AddonTestApp();
 
-    return app.create('request')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot',
-          additionalArguments: ['--serve-assets']
+      return app.create('request')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot',
+            additionalArguments: ['--serve-assets']
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('makes host available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-host'
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Host: localhost:49741');
+          expect(response.body).to.contain('Host from Instance Initializer: localhost:49741');
+        });
+    });
+
+    it('makes protocol available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-protocol'
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Protocol: http');
+          expect(response.body).to.contain('Protocol from Instance Initializer: http');
+        });
+    });
+
+    it('makes path available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-path'
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Path: /show-path');
+          expect(response.body).to.contain('Path from Instance Initializer: /show-path');
+        });
+    });
+
+    it('makes query params available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/list-query-params?foo=bar'
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Query Params: bar');
+          expect(response.body).to.contain('Query Params from Instance Initializer: bar');
+        });
+    });
+
+    it('makes cookies available via a service', function() {
+      var jar = request.jar();
+      var cookie = request.cookie('city=Cluj');
+
+      jar.setCookie(cookie, 'http://localhost:49741');
+
+      return get({
+        url: 'http://localhost:49741/list-cookies',
+        jar: jar
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Cookies: Cluj');
+          expect(response.body).to.contain('Cookies from Instance Initializer: Cluj');
+        });
+    });
+
+    it('makes headers available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/list-headers',
+        headers: { 'X-FastBoot-info': 'foobar' }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Headers: foobar');
+          expect(response.body).to.contain('Headers from Instance Initializer: foobar');
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('makes host available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/show-host'
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Host: localhost:49741');
-        expect(response.body).to.contain('Host from Instance Initializer: localhost:49741');
-      });
-  });
+    before(function() {
 
-  it('makes protocol available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/show-protocol'
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Protocol: http');
-        expect(response.body).to.contain('Protocol from Instance Initializer: http');
-      });
-  });
+      app = new AddonTestApp();
 
-  it('makes path available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/show-path'
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Path: /show-path');
-        expect(response.body).to.contain('Path from Instance Initializer: /show-path');
-      });
-  });
+      return app.create('request')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
 
-  it('makes query params available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/list-query-params?foo=bar'
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Query Params: bar');
-        expect(response.body).to.contain('Query Params from Instance Initializer: bar');
-      });
-  });
+    after(function() {
+      return app.stopServer();
+    });
 
-  it('makes cookies available via a service', function() {
-    var jar = request.jar();
-    var cookie = request.cookie('city=Cluj');
+    it('makes host available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-host',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Host: localhost:49741');
+          expect(response.body).to.contain('Host from Instance Initializer: localhost:49741');
+        });
+    });
 
-    jar.setCookie(cookie, 'http://localhost:49741');
+    it('makes protocol available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-protocol',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Protocol: http');
+          expect(response.body).to.contain('Protocol from Instance Initializer: http');
+        });
+    });
 
-    return get({
-      url: 'http://localhost:49741/list-cookies',
-      jar: jar
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Cookies: Cluj');
-        expect(response.body).to.contain('Cookies from Instance Initializer: Cluj');
-      });
-  });
+    it('makes path available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/show-path',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Path: /show-path');
+          expect(response.body).to.contain('Path from Instance Initializer: /show-path');
+        });
+    });
 
-  it('makes headers available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/list-headers',
-      headers: { 'X-FastBoot-info': 'foobar' }
-    })
-      .then(function(response) {
-        expect(response.body).to.contain('Headers: foobar');
-        expect(response.body).to.contain('Headers from Instance Initializer: foobar');
-      });
+    it('makes query params available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/list-query-params?foo=bar',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Query Params: bar');
+          expect(response.body).to.contain('Query Params from Instance Initializer: bar');
+        });
+    });
+
+    it('makes cookies available via a service', function() {
+      var jar = request.jar();
+      var cookie = request.cookie('city=Cluj');
+
+      jar.setCookie(cookie, 'http://localhost:49741');
+
+      return get({
+        url: 'http://localhost:49741/list-cookies',
+        headers: {
+          'Accept': 'text/html'
+        },
+        jar: jar
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Cookies: Cluj');
+          expect(response.body).to.contain('Cookies from Instance Initializer: Cluj');
+        });
+    });
+
+    it('makes headers available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/list-headers',
+        headers: {
+          'X-FastBoot-info': 'foobar',
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.body).to.contain('Headers: foobar');
+          expect(response.body).to.contain('Headers from Instance Initializer: foobar');
+        });
+    });
   });
 });

--- a/test/response-details-test.js
+++ b/test/response-details-test.js
@@ -8,42 +8,90 @@ var get = RSVP.denodeify(request);
 describe('response details', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
+    before(function() {
 
-    app = new AddonTestApp();
+      app = new AddonTestApp();
 
-    return app.create('response')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot',
-          additionalArguments: ['--serve-assets']
+      return app.create('response')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot',
+            additionalArguments: ['--serve-assets']
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('makes headers available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/echo-request-headers',
+        headers: { 'X-FastBoot-echo': 'i-should-be-echoed-back' }
+      })
+        .then(function(response) {
+          expect(response.headers).to.include.keys('x-fastboot-echoed-back');
+          expect(response.headers['x-fastboot-echoed-back']).to.include('i-should-be-echoed-back');
+        });
+    });
+
+    it('makes the status code available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/return-status-code-418'
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(418);
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('makes headers available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/echo-request-headers',
-      headers: { 'X-FastBoot-echo': 'i-should-be-echoed-back' }
-    })
-      .then(function(response) {
-        expect(response.headers).to.include.keys('x-fastboot-echoed-back');
-        expect(response.headers['x-fastboot-echoed-back']).to.include('i-should-be-echoed-back');
-      });
-  });
+    before(function() {
 
-  it('makes the status code available via a service', function() {
-    return get({
-      url: 'http://localhost:49741/return-status-code-418'
-    })
-      .then(function(response) {
-        expect(response.statusCode).to.equal(418);
-      });
+      app = new AddonTestApp();
+
+      return app.create('response')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('makes headers available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/echo-request-headers',
+        headers: {
+          'X-FastBoot-echo': 'i-should-be-echoed-back',
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.headers).to.include.keys('x-fastboot-echoed-back');
+          expect(response.headers['x-fastboot-echoed-back']).to.include('i-should-be-echoed-back');
+        });
+    });
+
+    it('makes the status code available via a service', function() {
+      return get({
+        url: 'http://localhost:49741/return-status-code-418',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(418);
+        });
+    });
   });
 });

--- a/test/serve-assets-test.js
+++ b/test/serve-assets-test.js
@@ -1,46 +1,86 @@
-var expect           = require('chai').expect;
-var RSVP             = require('rsvp');
-var request          = RSVP.denodeify(require('request'));
+var expect = require('chai').expect;
+var RSVP = require('rsvp');
+var request = RSVP.denodeify(require('request'));
 
-var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 describe('serve assets acceptance', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
+    before(function() {
 
-    app = new AddonTestApp();
+      app = new AddonTestApp();
 
-    return app.create('dummy')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot',
-          additionalArguments: ['--serve-assets']
+      return app.create('dummy')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot',
+            additionalArguments: ['--serve-assets']
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('/assets/vendor.js', function() {
+      return request('http://localhost:49741/assets/vendor.js')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.body).to.contain("Ember =");
+        });
+    });
+
+    it('/assets/dummy.js', function() {
+      return request('http://localhost:49741/assets/dummy.js')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.body).to.contain("this.route('posts')");
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('/assets/vendor.js', function() {
-    return request('http://localhost:49741/assets/vendor.js')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript");
-        expect(response.body).to.contain("Ember =");
-      });
-  });
+    before(function() {
 
-  it('/assets/dummy.js', function() {
-    return request('http://localhost:49741/assets/dummy.js')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript");
-        expect(response.body).to.contain("this.route('posts')");
-      });
+      app = new AddonTestApp();
+
+      return app.create('dummy')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('/assets/vendor.js', function() {
+      return request('http://localhost:49741/assets/vendor.js')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.body).to.contain("Ember =");
+        });
+    });
+
+    it('/assets/dummy.js', function() {
+      return request('http://localhost:49741/assets/dummy.js')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.body).to.contain("this.route('posts')");
+        });
+    });
   });
 });

--- a/test/shoebox-put-test.js
+++ b/test/shoebox-put-test.js
@@ -1,43 +1,86 @@
-var expect           = require('chai').expect;
-var RSVP             = require('rsvp');
-var request          = RSVP.denodeify(require('request'));
+var expect = require('chai').expect;
+var RSVP = require('rsvp');
+var request = RSVP.denodeify(require('request'));
 
-var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 describe('shoebox - put', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
-    app = new AddonTestApp();
+    before(function() {
+      app = new AddonTestApp();
 
-    return app.create('shoebox')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot'
+      return app.create('shoebox')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot'
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('put items into the shoebox', function() {
+      return request('http://localhost:49741/')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.body).to.contain(
+            '<script type="fastboot/shoebox" id="shoebox-key1">' +
+              '{"foo":"bar"}' +
+            '</script>'
+          );
+          expect(response.body).to.contain(
+            '<script type="fastboot/shoebox" id="shoebox-key2">' +
+              '{"zip":"zap"}' +
+            '</script>'
+          );
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('put items into the shoebox', function() {
-    return request('http://localhost:49741/')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.body).to.contain(
-          '<script type="fastboot/shoebox" id="shoebox-key1">' +
-            '{"foo":"bar"}' +
-          '</script>'
-        );
-        expect(response.body).to.contain(
-          '<script type="fastboot/shoebox" id="shoebox-key2">' +
-            '{"zip":"zap"}' +
-          '</script>'
-        );
-      });
+    before(function() {
+      app = new AddonTestApp();
+
+      return app.create('shoebox')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('put items into the shoebox', function() {
+      return request({
+        url: 'http://localhost:49741/',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.body).to.contain(
+            '<script type="fastboot/shoebox" id="shoebox-key1">' +
+              '{"foo":"bar"}' +
+            '</script>'
+          );
+          expect(response.body).to.contain(
+            '<script type="fastboot/shoebox" id="shoebox-key2">' +
+              '{"zip":"zap"}' +
+            '</script>'
+          );
+        });
+    });
   });
 });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -1,73 +1,161 @@
-var expect           = require('chai').expect;
-var RSVP             = require('rsvp');
-var request          = RSVP.denodeify(require('request'));
+var expect = require('chai').expect;
+var RSVP = require('rsvp');
+var request = RSVP.denodeify(require('request'));
 
-var AddonTestApp     = require('ember-cli-addon-tests').AddonTestApp;
+var AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
 
 describe('simple acceptance', function() {
   this.timeout(300000);
 
-  var app;
+  describe('with fastboot command', function() {
+    var app;
 
-  before(function() {
-    app = new AddonTestApp();
+    before(function() {
+      app = new AddonTestApp();
 
-    return app.create('dummy')
-      .then(function() {
-        return app.startServer({
-          command: 'fastboot'
+      return app.create('dummy')
+        .then(function() {
+          return app.startServer({
+            command: 'fastboot'
+          });
         });
-      });
+    });
+
+    after(function() {
+      return app.stopServer();
+    });
+
+    it('/ HTML contents', function() {
+      return request('http://localhost:49741/')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("Welcome to Ember.js");
+        });
+    });
+
+    it('/posts HTML contents', function() {
+      return request('http://localhost:49741/posts')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("Welcome to Ember.js");
+          expect(response.body).to.contain("Posts Route!");
+        });
+    });
+
+    it('/not-found HTML contents', function() {
+      return request('http://localhost:49741/not-found')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(404);
+          expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
+          expect(response.body).to.equal("Not Found");
+        });
+    });
+
+    it('/boom HTML contents', function() {
+      return request('http://localhost:49741/boom')
+        .then(function(response) {
+          expect(response.statusCode).to.equal(500);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("BOOM");
+        });
+    });
+
+    it('/assets/vendor.js', function() {
+      return request('http://localhost:49741/assets/vendor.js')
+        .then(function(response) {
+          // Asset serving is off by default
+          expect(response.statusCode).to.equal(404);
+          expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
+          expect(response.body).to.equal("Not Found");
+        });
+    });
   });
 
-  after(function() {
-    return app.stopServer();
-  });
+  describe('with serve command', function() {
+    var app;
 
-  it('/ HTML contents', function() {
-    return request('http://localhost:49741/')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
-        expect(response.body).to.contain("Welcome to Ember.js");
-      });
-  });
+    before(function() {
+      app = new AddonTestApp();
 
-  it('/posts HTML contents', function() {
-    return request('http://localhost:49741/posts')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
-        expect(response.body).to.contain("Welcome to Ember.js");
-        expect(response.body).to.contain("Posts Route!");
-      });
-  });
+      return app.create('dummy')
+        .then(function() {
+          return app.startServer({
+            command: 'serve'
+          });
+        });
+    });
 
-  it('/not-found HTML contents', function() {
-    return request('http://localhost:49741/not-found')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(404);
-        expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
-        expect(response.body).to.equal("Not Found");
-      });
-  });
+    after(function() {
+      return app.stopServer();
+    });
 
-  it('/boom HTML contents', function() {
-    return request('http://localhost:49741/boom')
-      .then(function(response) {
-        expect(response.statusCode).to.equal(500);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
-        expect(response.body).to.contain("BOOM");
-      });
-  });
+    it('/ HTML contents', function() {
+      return request({
+        url: 'http://localhost:49741/',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("Welcome to Ember.js");
+        });
+    });
 
-  it('/assets/vendor.js', function() {
-    return request('http://localhost:49741/assets/vendor.js')
-      .then(function(response) {
-        // Asset serving is off by default
-        expect(response.statusCode).to.equal(404);
-        expect(response.headers["content-type"]).to.eq("text/plain; charset=utf-8");
-        expect(response.body).to.equal("Not Found");
-      });
+    it('/posts HTML contents', function() {
+      return request({
+        url: 'http://localhost:49741/posts',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("Welcome to Ember.js");
+          expect(response.body).to.contain("Posts Route!");
+        });
+    });
+
+    it('/not-found HTML contents', function() {
+      return request({
+        url: 'http://localhost:49741/not-found',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+          expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
+        });
+    });
+
+    it('/boom HTML contents', function() {
+      return request({
+        url: 'http://localhost:49741/boom',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(500);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("BOOM");
+        });
+    });
+
+    it('/assets/vendor.js', function() {
+      return request('http://localhost:49741/assets/vendor.js')
+        .then(function(response) {
+          // Asset serving is on by default
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.body).to.contain("Ember =");
+        });
+    });
   });
 });


### PR DESCRIPTION
**TL;DR: fixes https://github.com/ember-fastboot/ember-cli-fastboot/issues/274 . This will unblock one of the FastBoot 1.0 blockers.** 

## Motivation
Currently FastBoot provides users to serve the base page and the assets via the `ember fastboot` command. It primarily spins up an express server that is responsible for serving the request with a fastboot replaced base page and serves other assets from disk. However, this is similar to what `ember cli` provides via `ember serve`. Since we are not the infrastructure provided by ember-cli, development with `ember fastboot` has become very error prone for various reasons. The PR attempts to resolve those development concerns. 

## How it works
ember-cli@2.12.0-beta.1 and above [introduced a public API](https://github.com/ember-cli/rfcs/pull/80) in ember-cli that allows addons to be responsible for serving the base page and/or assets while still be able to consume the other nice features of `ember serve`. It does so by splitting the task of watching the build and serving assets into different middleware. Infrastructures like FastBoot can then hook a middleware between the watcher and server middleware and be responsible for serving the base page request. 

If apps are using `ember-cli@2.12.0-beta.1` and above, they will be able to serve fastboot rendered base page using `ember serve` and continue using other features of `ember serve`. For apps running ember-cli version below 2.12.0-beta.1, they will not be able to use `ember serve` with FastBoot.

With the new serving logic, you can use `curl` with `ember serve`:
`curl 'http://localhost:4200/' -H 'Accept: text/html'` 

This PR does the following:
- [x] Marks `ember-cli-fastboot` addon to run before `broccoli-serve-files` addon. `broccoli-serve-files` is an in-repo addon in ember-cli
- [x] Uses `serverMiddleware` API of `ember-cli` to provide a middleware to use `fastboot-express-middleware` when there is a base request. 
- [x] Added a message when fastboot is serving the base page
- [x] Added deprecation message in `ember fastboot`
- [x] For any other requests other than base page, it forwards the request to the next middleware in the chain.
- [x] Live reloads the FastBoot sandbox with rebuilt app and vendor files whenever there is a rebuild.
- [x] Fixed existing tests
- [x] Added new tests that test the same functionality as `ember fastboot`

## Advantages
With using `ember serve` to have FastBoot serve the initial base page request we get the following features for free:
- Ability to show build errors when the initial page request is made so the development is easier and better
- Not requiring any infrastructure to explicitly build an express app just for serving.
- Ability to have other assets served by `ember cli` as it does for vanilla app
- Ability to use a proxy server for serving any API requests or any other requests using `ember serve --proxy=http://localhost:3000`
- Ability to have live reload in the browser using `ember-cli` live reload functionality.
- Ability to load the built assets from `tmp` directory instead of dist.

## Deprecation of `ember fastboot`
Since this PR does similar to what `ember fastboot --watch --serve-assets` provides, we will be deprecating `ember fastboot` command. 

## Future TODOs
Following are the minor enhancements that I would like to fix on after this PR lands. They do not block this PR.
- [ ] Make FastBoot live reloading much smarter. We do not need to reload the sandbox if there are only CSS changes. Therefore, we could use `fs-tree-diff` to see if any of the app/vendor files have changed on rebuild and only load it sandbox then.
- [ ] Allow developers to provide `sandboxGlobals` and/or custom sandbox class when serving using FastBoot in development. No one seems to be using this so just added a TODO for now. 
- [ ] Provide a way to turn off fastboot serving at runtime without needing to remove `ember-cli-fastboot`

cc: @rwjblue @tomdale @danmcclain @stefanpenner @josemarluedke @arjansingh 