### PR TITLE
add test coverage for noop redirects

### DIFF
--- a/test/fastboot-location-test.js
+++ b/test/fastboot-location-test.js
@@ -98,4 +98,38 @@ describe('FastBootLocation', function () {
       expect(response.body).to.contain('/my-root/test-passed');
     });
   });
+
+  it('should NOT redirect when transitionTo is called with identical route name', function () {
+    return get({
+      url: 'http://localhost:49741/my-root/noop-transition-to',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal('/my-root/noop-transition-to');
+
+      expect(response.body).to.contain('Redirect to self');
+    });
+  });
+
+  it('should NOT redirect when replaceWith is called with identical route name', function () {
+    return get({
+      url: 'http://localhost:49741/my-root/noop-replace-with',
+      followRedirect: false
+    })
+    .then(function (response) {
+      if (response.statusCode === 500) throw new Error (response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal('/my-root/noop-replace-with');
+
+      expect(response.body).to.contain('Redirect to self');
+    });
+  });
 });

--- a/test/fixtures/fastboot-location/app/router.js
+++ b/test/fixtures/fastboot-location/app/router.js
@@ -7,6 +7,8 @@ const Router = Ember.Router.extend({
 });
 
 Router.map(function() {
+  this.route('noop-transition-to');
+  this.route('noop-replace-with');
   this.route('redirect-on-intermediate-transition-to');
   this.route('redirect-on-transition-to');
   this.route('redirect-on-replace-with');

--- a/test/fixtures/fastboot-location/app/routes/noop-replace-with.js
+++ b/test/fixtures/fastboot-location/app/routes/noop-replace-with.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.replaceWith('noop-replace-with');
+  }
+});

--- a/test/fixtures/fastboot-location/app/routes/noop-transition-to.js
+++ b/test/fixtures/fastboot-location/app/routes/noop-transition-to.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  beforeModel() {
+    this.replaceWith('noop-transition-to');
+  }
+});

--- a/test/fixtures/fastboot-location/app/templates/noop-replace-with.hbs
+++ b/test/fixtures/fastboot-location/app/templates/noop-replace-with.hbs
@@ -1,0 +1,3 @@
+<h1>Redirect to self</h1>
+
+<p>We should render this because a redirect to self should be a noop in Ember.</p>

--- a/test/fixtures/fastboot-location/app/templates/noop-transition-to.hbs
+++ b/test/fixtures/fastboot-location/app/templates/noop-transition-to.hbs
@@ -1,0 +1,3 @@
+<h1>Redirect to self</h1>
+
+<p>We should render this because a redirect to self should be a noop in Ember.</p>


### PR DESCRIPTION
Since these redirects also enter our `none` location override, I was curious if they worked correctly. I'm curious no more!