### PR TITLE
Enable a way to disable fastboot serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,13 @@ ember install ember-cli-fastboot
 * `ember fastboot --serve-assets`
 * Visit your app at `http://localhost:3000`.
 
-**Note**: If your app is running ember-cli v2.12.0-beta.1+, you can just use `ember serve` instead of `ember fastboot --serve-assets`.
+### With `ember-cli` version 2.12.0-beta.1 and above
+If your app is running ember-cli v2.12.0-beta.1+, you can just use `ember serve` instead of `ember fastboot --serve-assets` and visit at `http://localhost:4200/`.
+
+Optionally you can even disable the fastboot serving at runtime using the `fastboot` query parameter. Example to turn off fastboot serving,
+visit your app at `http://localhost:4200/?fastboot=false`. If you want to turn on fastboot serving again, simply visit at `http://localhost:4200/?fastboot=true` or `http://localhost:4200/`.
+
+You can even disable serving fastboot with `ember serve` using an environment flag: `FASTBOOT_DISABLED=true ember serve`. If you have disabled building fastboot assets using the same flag as described [here](https://github.com/ember-fastboot/ember-cli-fastboot#double-build-times-and-no-incremental-builds), remember to also disable serving fastboot assets when using `ember serve`.
 
 You may be shocked to learn that minified code runs faster in Node than
 non-minified code, so you will probably want to run the production
@@ -392,7 +398,7 @@ inside of the sandbox environment. For this reason, it's encouraged to [disable 
 Due to limitations in Ember CLI, builds take twice as long to generate the
 second set of FastBoot assets. This also means incremental builds with
 live reload don't work either. This aims to be resolved by FastBoot 1.0.
-In the mean time, we introduce a short-circuit evironment flag to not do
+In the mean time, we introduce a short-circuit environment flag to not do
 a FastBoot build:
 
 ```

--- a/index.js
+++ b/index.js
@@ -152,12 +152,13 @@ module.exports = {
       // that version contains API to hook fastboot into ember-cli
 
       app.use((req, resp, next) => {
+        var fastbootQueryParam = (req.query.hasOwnProperty('fastboot') && req.query.fastboot === 'false') ? false : true;
+        var enableFastBootServe = !process.env.FASTBOOT_DISABLED && fastbootQueryParam;
         var broccoliHeader = req.headers['x-broccoli'];
         var outputPath = broccoliHeader['outputPath'];
 
-        if (broccoliHeader['url'] === req.serveUrl) {
+        if (broccoliHeader['url'] === req.serveUrl && enableFastBootServe) {
           // if it is a base page request, then have fastboot serve the base page
-          // TODO(future): provide a way to turn this off without needing to uninstall this addon
           if (!this.fastboot) {
             // TODO(future): make this configurable for allowing apps to pass sandboxGlobals
             // and custom sandbox class

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -105,6 +105,34 @@ describe('simple acceptance', function() {
         });
     });
 
+    it('with fastboot query parameter turned on', function() {
+      return request({
+        url: 'http://localhost:49741/?fastboot=true',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+          expect(response.body).to.contain("Welcome to Ember.js");
+        });
+    });
+
+    it('with fastboot query parameter turned off', function() {
+      return request({
+        url: 'http://localhost:49741/?fastboot=false',
+        headers: {
+          'Accept': 'text/html'
+        }
+      })
+        .then(function(response) {
+          expect(response.statusCode).to.equal(200);
+          expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+          expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
+        });
+    });
+
     it('/posts HTML contents', function() {
       return request({
         url: 'http://localhost:49741/posts',


### PR DESCRIPTION
**TL;DR: Fixes [issue#358](https://github.com/ember-fastboot/ember-cli-fastboot/issues/358)**

This PR provides a way to disable fastboot serving with `ember serve` via the following:
- [x] Runtime query parameter `fastboot` when using `ember serve`. In order to disable fastboot serving on per request basis use: `http://localhost:4200/?fastboot=false`.
- [x] Provides a way to disable fastboot serving via environment variable `FASTBOOT_DISABLED`. The same environment variable is used for disabling double builds.
- [x] Updates README.

cc: @rwjblue @stefanpenner @mfazekas @danmcclain 