### PR TITLE
Expose API for fastboot addons to update fastboot manifest.

### DIFF
--- a/index.js
+++ b/index.js
@@ -177,7 +177,7 @@ module.exports = {
           // forward the request to the next middleware (example other assets, proxy etc)
           next();
         }
-      })
+      });
     }
   },
 

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -115,6 +115,20 @@ FastBootConfig.prototype.readAssetManifest = function() {
   }
 };
 
+FastBootConfig.prototype.updateFastBootManifest = function(manifest) {
+  this.project.addons.forEach(function(addon) {
+    if (addon.updateFastBootManifest) {
+      manifest = addon.updateFastBootManifest(manifest);
+
+      if (!manifest) {
+        throw new Error(`${addon.name} did not return the updated manifest from updateFastBootManifest hook.`);
+      }
+    }
+  });
+
+  return manifest;
+}
+
 FastBootConfig.prototype.buildManifest = function() {
   var appFileName = path.basename(this.outputPaths.app.js).split('.')[0];
   var appFile = 'fastboot/' + appFileName + '.js';
@@ -126,6 +140,8 @@ FastBootConfig.prototype.buildManifest = function() {
     vendorFiles: [vendorFile],
     htmlFile: this.htmlFile
   };
+
+  manifest = this.updateFastBootManifest(manifest);
 
   var rewrittenAssets = this.readAssetManifest();
 

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -64,9 +64,9 @@ describe('generating package.json', function() {
       var pkg = fs.readJsonSync(app.filePath('/dist/package.json'));
 
       expect(pkg.fastboot.manifest).to.deep.equal({
-        appFiles: ['fastboot/module-whitelist.js'],
+        appFiles: ['fastboot/module-whitelist.js', 'ember-fastboot-build-example/bar.js'],
         htmlFile: 'index.html',
-        vendorFiles: ['fastboot/vendor.js']
+        vendorFiles: ['ember-fastboot-build-example/foo.js', 'fastboot/vendor.js']
       });
     });
 
@@ -221,7 +221,8 @@ function addFastBootDeps(app) {
     pkg['devDependencies']['fake-addon-2'] = "*";
     pkg['fastbootDependencies'] = ["rsvp"];
     pkg['dependencies'] = {
-      rsvp: "3.2.1"
+      rsvp: "3.2.1",
+      "ember-fastboot-build-example": "0.1.1"
     };
   });
 }


### PR DESCRIPTION
## Motivation
Currently, FastBoot runs two ember builds to fork and build fastboot assets. When it runs the fastboot build it sets an environment variable `process.env.EMBER_CLI_FASTBOOT` to be `true`.  At present a lot of addons are relying on this environment variable to append libraries into the fastboot assets (example `ember-network`).

Moreover another usecase is to allow addons like `ember-engines` to write and load additional assets in the FastBoot sandbox.

With #360, this environment variable will no longer be exposed or valid. Therefore, we want to expose an API from `ember-cli-fastboot` to allow other fastboot compatible addons to be able to provide paths under `dist` from where additional `vendor` or `app` specific assets should be loaded in sandbox. With addons being able to leverage this API when the build issue is resolved they will automatically become backward compatible.

## How does it work
In order for an addon to load additional assets in the sandbox (in any order), they need to either update `vendorFiles` or `appFiles` key in the fastboot manifest. Therefore, they will define `updateFastBootManifest` hook in their `index.js` which takes in the `manifest` as input, updates the manifest and returns it back:
```javascript
   updateFastBootManifest: function(manifest) {
      manifest.vendorFiles.unshift(<add some path>);
      manifest.appFiles.push(<add some path>);
     
     return manifest;
  }
```

An addon can decide to update the manifest enteries however they like. If the `manifest` key is not returned, the build will fail with an error message as : `<addon name> did not return the updated manifest from updateFastBootManifest hook.`

**Example**: See [`ember-fastboot-build-example`](https://github.com/kratiahuja/ember-fastboot-build-example/blob/master/index.js#L11) addon for a simple example of how to load assets

## TODO
- [ ] Update README with instructions and example of how to use the new API
- [ ] Update fastboot website with new API

cc: @rwjblue @tomdale @danmcclain @ryanone @tsubomii @arjansingh @simonihmig 