### PR TITLE
Fix beta checks correctly by using `gt` API

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ module.exports = {
     var app = options.app;
     var options = options.options;
 
-    if (emberCliVersion.satisfies('>= 2.12.0-beta.1')) {
+    if (emberCliVersion.gt('2.12.0-beta.0')) {
       // only run the middleware when ember-cli version for app is above 2.12.0-beta.1 since
       // that version contains API to hook fastboot into ember-cli
 

--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -81,7 +81,7 @@ module.exports = function(addon) {
       var checker = new VersionChecker(this);
       var dep = checker.for('ember-cli', 'npm');
 
-      if (dep.satisfies('>= 2.12.0-beta.1')) {
+      if (dep.gt('2.12.0-beta.0')) {
         this.ui.writeDeprecateLine('`ember fastboot --serve-assets` is deprecated. Please use `ember serve` to serve your fastboot assets.');
       } else {
         this.ui.writeWarnLine('`ember fastboot` will no longer work after FastBoot 1.0 is released.');


### PR DESCRIPTION
Apparently `satisfies` does not conform to beta channel checks correctly.

```js
> semver.satisfies('2.13.0-beta.1', '>=2.12.0-beta.1')
false

> semver.gt('2.13.0-beta.1', '2.12.0-beta.1')
true
```

cc: @rwjblue @danmcclain 