### PR TITLE
Use relative protocol for redirects

### DIFF
--- a/app/locations/none.js
+++ b/app/locations/none.js
@@ -38,9 +38,8 @@ export default Ember.NoneLocation.extend({
         let isTransitioning = currentPath !== path;
 
         if (isTransitioning) {
-          let protocol = get(this, '_request.protocol');
           let host = get(this, '_request.host');
-          let redirectURL = `${protocol}://${host}${path}`;
+          let redirectURL = `//${host}${path}`;
 
           response.statusCode = this.get('_redirectCode');
           response.headers.set('location', redirectURL);

--- a/test/fastboot-location-config-test.js
+++ b/test/fastboot-location-config-test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const expect = require('chai').expect;
+const RSVP = require('rsvp');
+const request = RSVP.denodeify(require('request'));
+
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('FastBootLocation Configuration', function() {
+  this.timeout(300000);
+
+  let app;
+
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('fastboot-location-config').then(function() {
+      return app.startServer({
+        command: 'serve'
+      });
+    });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('should use the redirect code provided by the EmberApp', function() {
+    return request({
+      url: 'http://localhost:49741/redirect-on-transition-to',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(302);
+      expect(response.headers.location).to.equal('//localhost:49741/test-passed');
+    });
+  });
+
+  describe('when fastboot.fastbootHeaders is false', function() {
+    it('should not send the "x-fastboot-path" header on a redirect', function() {
+      return request({
+        url: 'http://localhost:49741/redirect-on-transition-to',
+        followRedirect: false,
+        headers: {
+          Accept: 'text/html'
+        }
+      }).then(function(response) {
+        if (response.statusCode === 500) throw new Error(response.body);
+        expect(response.headers).to.not.include.keys(['x-fastboot-path']);
+      });
+    });
+  });
+});

--- a/test/fixtures/fastboot-location-config/config/environment.js
+++ b/test/fixtures/fastboot-location-config/config/environment.js
@@ -2,7 +2,8 @@
 
 module.exports = function(environment) {
   var ENV = {
-    baseUrl: '/',
+    rootURL: '/',
+    locationType: 'auto',
     environment: environment,
     modulePrefix: 'fastboot-location-config',
     fastboot: {


### PR DESCRIPTION
This allow apps that use https in the load balancer to redirect correctly. Currently if you have a https in the load balancer, the protocol that the express server will see is http, so when redirecting it will also use http instead of https. Now with relative protocol, it will use https instead.

I had a conversation in slack about it, and I know other people had issues like this.