### PR TITLE
Add deprecation message around soon to be dropped `ember fastboot` command

### DIFF
--- a/lib/commands/fastboot.js
+++ b/lib/commands/fastboot.js
@@ -78,13 +78,15 @@ module.exports = function(addon) {
     },
 
     printDeprecations(options) {
+      this.ui.writeDeprecateLine('`ember fastboot` will no longer work in non-beta releases of ember-cli-fastboot. Please switch to `ember serve` which supports FastBoot.');
+
       var checker = new VersionChecker(this);
       var dep = checker.for('ember-cli', 'npm');
 
       if (dep.gte('2.12.0-beta.1')) {
         this.ui.writeDeprecateLine('`ember fastboot --serve-assets` is deprecated. Please use `ember serve` to serve your fastboot assets.');
       } else {
-        this.ui.writeWarnLine('`ember fastboot` will no longer work after FastBoot 1.0 is released.');
+        this.ui.writeDeprecateLine('`ember fastboot` will no longer work after FastBoot 1.0 is released.');
       }
     },
 

--- a/test/serve-assets-test.js
+++ b/test/serve-assets-test.js
@@ -69,7 +69,7 @@ describe('serve assets acceptance', function() {
       return request('http://localhost:49741/assets/vendor.js')
         .then(function(response) {
           expect(response.statusCode).to.equal(200);
-          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
           expect(response.body).to.contain("Ember =");
         });
     });
@@ -78,7 +78,7 @@ describe('serve assets acceptance', function() {
       return request('http://localhost:49741/assets/dummy.js')
         .then(function(response) {
           expect(response.statusCode).to.equal(200);
-          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
           expect(response.body).to.contain("this.route('posts')");
         });
     });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -181,7 +181,7 @@ describe('simple acceptance', function() {
         .then(function(response) {
           // Asset serving is on by default
           expect(response.statusCode).to.equal(200);
-          expect(response.headers["content-type"]).to.eq("application/javascript");
+          expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
           expect(response.body).to.contain("Ember =");
         });
     });


### PR DESCRIPTION
`ember fastboot` will soon be dropped. We should add a clear deprecation that `ember fastboot` will not work in RC releases.

This only needs to go in `beta` branch. 

Fixes #396 (second TODO)

cc: @stefanpenner @danmcclain