### PR TITLE
Fix fingerprinting assets correctly in fastboot

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,6 +46,13 @@ module.exports = {
     // set autoRun to false since we will conditionally include creating app when app files
     // is eval'd in app-boot
     app.options.autoRun = false;
+
+    if (app.options.fingerprint) {
+      // set generateAssetMap to be true so that manifest files can be correctly written
+      // in package.json
+      app.options.fingerprint.generateAssetMap = true;
+    }
+
     // get the app registry object and app name so that we can build the fastboot
     // tree
     this._appRegistry = app.registry;

--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -6,6 +6,7 @@ const uniq   = require('lodash.uniq');
 const md5Hex = require('md5-hex');
 const path   = require('path');
 const Plugin = require('broccoli-plugin');
+const SilentError = require('silent-error');
 
 const stringify = require('json-stable-stringify');
 
@@ -19,7 +20,21 @@ module.exports = class FastBootConfig extends Plugin {
     });
 
     this.project = options.project;
-    // what if app does not set generateAssetMap option? fastboot will be broken otherwise
+
+    this.name = options.name;
+    this.assetMapEnabled = options.assetMapEnabled;
+    this.ui = options.ui;
+    this.fastbootAppConfig = options.fastbootAppConfig;
+    this.outputPaths = options.outputPaths;
+    this.appConfig = options.appConfig;
+    this._fileToChecksumMap = {};
+
+    if (this.fastbootAppConfig && this.fastbootAppConfig.htmlFile) {
+      this.htmlFile = this.fastbootAppConfig.htmlFile;
+    } else {
+      this.htmlFile = 'index.html';
+    }
+
     let defaultAssetMapPath = 'assets/assetMap.json';
     let assetRev = this.project.addons.find(addon => addon.name === 'broccoli-asset-rev');
 
@@ -36,20 +51,6 @@ module.exports = class FastBootConfig extends Plugin {
     }
 
     this.assetMapPath = this.assetMapPath || options.assetMapPath || defaultAssetMapPath;
-
-    this.name = options.name;
-    this.assetMapEnabled = options.assetMapEnabled;
-    this.ui = options.ui;
-    this.fastbootAppConfig = options.fastbootAppConfig;
-    this.outputPaths = options.outputPaths;
-    this.appConfig = options.appConfig;
-    this._fileToChecksumMap = {};
-
-    if (this.fastbootAppConfig && this.fastbootAppConfig.htmlFile) {
-      this.htmlFile = this.fastbootAppConfig.htmlFile;
-    } else {
-      this.htmlFile = 'index.html';
-    }
   }
 
 
@@ -123,16 +124,15 @@ module.exports = class FastBootConfig extends Plugin {
   };
 
   readAssetManifest() {
-    let ui = this.ui;
     let assetMapPath = path.join(this.inputPaths[0], this.assetMapPath);
-    let assetMapEnabled = this.assetMapEnabled;
+    const assetMapEnabled = this.assetMapEnabled;
 
     try {
       let assetMap = JSON.parse(fs.readFileSync(assetMapPath));
       return assetMap;
     } catch (e) {
       if (this.assetMapEnabled) {
-        ui.writeLine(fmt("assetMap.json not found at: %s", assetMapPath), ui.WARNING);
+        throw new SilentError("assetMap.json not found at: %s. Make sure `generateAssetMap` is set to true", assetMapPath);
       }
     }
   }

--- a/test/fixtures/module-whitelist/ember-cli-build.js
+++ b/test/fixtures/module-whitelist/ember-cli-build.js
@@ -1,10 +1,6 @@
 module.exports = function(defaults) {
   var EmberApp = require('ember-cli/lib/broccoli/ember-app');
-  var app = new EmberApp(defaults, {
-    fingerprint: {
-      generateAssetMap: true
-    }
-  });
+  var app = new EmberApp(defaults, {});
 
   return app.toTree();
 };


### PR DESCRIPTION
Fixes #424 

- [x] Sets `generateAssetMap` option to be true if `broccoli-asset-rev` is present
- [x] If the asset map isn't present and asset map is enabled, we were throwing a warning. Changed that to error since build should fail
- [x] Removed `generateAssetMap` set to true from test

Our tests were masking the problem. 

cc: @rwjblue 