### PR TITLE
BUGFIX: Error logs only showing [Object object]

### DIFF
--- a/fastboot/initializers/error-handler.js
+++ b/fastboot/initializers/error-handler.js
@@ -12,7 +12,7 @@ export default {
     if (!Ember.onerror) {
       // if no onerror handler is defined, define one for fastboot environments
       Ember.onerror = function(err) {
-        let errorMessage = `There was an error running your app in fastboot. More info about the error: \n ${err.stack || err}`;
+        let errorMessage = `There was an error running your app in fastboot. More info about the error: \n ${err.stack || JSON.stringify(err)}`;
         Ember.Logger.error(errorMessage);
       }
     }


### PR DESCRIPTION
If an error-object that is not an `Error` is propagated, the FastBoot logs show

> There was an error running your app in fastboot. More info about the error:
> [Object object]

This fixes that issue.