### PR TITLE
Improve explanation for importing incompatible libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,13 +356,14 @@ export default Ember.Route.extend({
 
 ### Disabling incompatible dependencies
 
-There are two places where the inclusion of incompatible JavaScript libraries could
-occur:
+There are two places where the inclusion of incompatible JavaScript libraries could occur:
 
  1. `app.import` in the application's `ember-cli-build.js`
  2. `app.import` in an addon's `included` hook
+ 
+There is no way to exclude incompatible libraries imported from the application's `ember-cli-build.js`. Instead, you will need to create an in-repo addon and include your libraries from there.    
 
-You can include the incompatible Javascript libraries by wrapping them with a `FastBoot` variable check. In the browser, `FastBoot` global variable is not defined.
+Within your addon, you can include the incompatible Javascript libraries by wrapping them with a `FastBoot` variable check. In the browser, `FastBoot` global variable is not defined.
 
 ```js
 var map = require('broccoli-stew').map;


### PR DESCRIPTION
A lot of the documentation here seems targeted at addon authors rather than regular users of Ember CLI. I don't think it was made clear to the latter group that they absolutely cannot use `ember-cli-build.js` anymore and instead must create an in-repo addon for the sole purpose of importing FastBoot-incompatible JS libraries.