### PR TITLE
Add fastboot-location-test back

### DIFF
--- a/test/fastboot-location-test.js
+++ b/test/fastboot-location-test.js
@@ -1,0 +1,158 @@
+'use strict';
+
+const expect = require('chai').expect;
+const RSVP = require('rsvp');
+const request = RSVP.denodeify(require('request'));
+
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('FastBootLocation', function() {
+  this.timeout(300000);
+
+  let app;
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('fastboot-location').then(function() {
+      return app.startServer({
+        command: 'serve'
+      });
+    });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('should NOT redirect when no transition is called', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/test-passed',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/test-passed'
+      );
+
+      expect(response.body).to.contain('The Test Passed!');
+    });
+  });
+
+  it('should NOT redirect when intermediateTransitionTo is called', function() {
+    return request({
+      url:
+        'http://localhost:49741/my-root/redirect-on-intermediate-transition-to',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/redirect-on-intermediate-transition-to'
+      );
+
+      expect(response.body).to.not.contain('Welcome to Ember');
+      expect(response.body).to.not.contain('The Test Passed!');
+    });
+  });
+
+  it('should redirect when transitionTo is called', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/redirect-on-transition-to',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(307);
+
+      expect(response.headers).to.include.keys(['location', 'x-fastboot-path']);
+      expect(response.headers.location).to.equal(
+        'http://localhost:49741/my-root/test-passed'
+      );
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/test-passed'
+      );
+      expect(response.body).to.contain('Redirecting to');
+      expect(response.body).to.contain('/my-root/test-passed');
+    });
+  });
+
+  it('should redirect when replaceWith is called', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/redirect-on-replace-with',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(307);
+
+      expect(response.headers).to.include.keys(['location', 'x-fastboot-path']);
+      expect(response.headers.location).to.equal(
+        'http://localhost:49741/my-root/test-passed'
+      );
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/test-passed'
+      );
+      expect(response.body).to.contain('Redirecting to');
+      expect(response.body).to.contain('/my-root/test-passed');
+    });
+  });
+
+  it('should NOT redirect when transitionTo is called with identical route name', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/noop-transition-to',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/noop-transition-to'
+      );
+
+      expect(response.body).to.contain('Redirect to self');
+    });
+  });
+
+  it('should NOT redirect when replaceWith is called with identical route name', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/noop-replace-with',
+      followRedirect: false,
+      headers: {
+        Accept: 'text/html'
+      }
+    }).then(function(response) {
+      if (response.statusCode === 500) throw new Error(response.body);
+      expect(response.statusCode).to.equal(200);
+
+      expect(response.headers).to.not.include.keys('location');
+      expect(response.headers).to.include.keys('x-fastboot-path');
+      expect(response.headers['x-fastboot-path']).to.equal(
+        '/my-root/noop-replace-with'
+      );
+
+      expect(response.body).to.contain('Redirect to self');
+    });
+  });
+});

--- a/test/fixtures/fastboot-location/config/environment.js
+++ b/test/fixtures/fastboot-location/config/environment.js
@@ -3,6 +3,7 @@
 module.exports = function(environment) {
   var ENV = {
     rootURL: '/my-root/',
+    locationType: 'auto',
     environment: environment,
     modulePrefix: 'fastboot-location',
     fastboot: {


### PR DESCRIPTION
This test was removed in #398, but we need to have tests for these use cases.

It seems all tests fails because we are passing a rootURL and that doesn't seem to work at the moment.

I would love someone to pick this up and fix these tests.

cc/ @kratiahuja 