### PR TITLE
Fix serving FastBoot when app has rootUrl defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ module.exports = {
         const broccoliHeader = req.headers['x-broccoli'];
         const outputPath = broccoliHeader['outputPath'];
 
-        if (broccoliHeader['url'] === req.serveUrl && enableFastBootServe) {
+        if (req.serveUrl && enableFastBootServe) {
           // if it is a base page request, then have fastboot serve the base page
           if (!this.fastboot) {
             // TODO(future): make this configurable for allowing apps to pass sandboxGlobals

--- a/test/fixtures/root-url/app/templates/application.hbs
+++ b/test/fixtures/root-url/app/templates/application.hbs
@@ -1,0 +1,3 @@
+<h2 id="title">Welcome to Ember.js</h2>
+
+{{outlet}}

--- a/test/fixtures/root-url/config/environment.js
+++ b/test/fixtures/root-url/config/environment.js
@@ -1,0 +1,12 @@
+'use strict';
+
+module.exports = function(environment) {
+  var ENV = {
+    rootURL: '/my-root/',
+    environment: environment,
+    modulePrefix: 'root-url',
+    locationType: 'auto'
+  };
+
+  return ENV;
+};

--- a/test/root-url-test.js
+++ b/test/root-url-test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const expect = require('chai').expect;
+const RSVP = require('rsvp');
+const request = RSVP.denodeify(require('request'));
+
+const AddonTestApp = require('ember-cli-addon-tests').AddonTestApp;
+
+describe('rootUrl acceptance', function() {
+  this.timeout(300000);
+
+  let app;
+
+  before(function() {
+    app = new AddonTestApp();
+
+    return app.create('root-url')
+      .then(function() {
+        return app.startServer({
+          command: 'serve'
+        });
+      });
+  });
+
+  after(function() {
+    return app.stopServer();
+  });
+
+  it('/ HTML contents', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/',
+      headers: {
+        'Accept': 'text/html'
+      }
+    })
+      .then(function(response) {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.body).to.contain("Welcome to Ember.js");
+      });
+  });
+
+  it('with fastboot query parameter turned on', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/?fastboot=true',
+      headers: {
+        'Accept': 'text/html'
+      }
+    })
+      .then(function(response) {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.body).to.contain("Welcome to Ember.js");
+      });
+  });
+
+  it('with fastboot query parameter turned off', function() {
+    return request({
+      url: 'http://localhost:49741/my-root/?fastboot=false',
+      headers: {
+        'Accept': 'text/html'
+      }
+    })
+      .then(function(response) {
+        expect(response.statusCode).to.equal(200);
+        expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+        expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
+      });
+  });
+});


### PR DESCRIPTION
Fixes #441 

We only need to check if `req.serveUrl` is defined to make sure it is a `index.html` request. `req.serveUrl` is set by the history middleware in `ember-cli` that runs before this middleware. For asset requests, `req.serveUrl` will be undefined so those requests will be served by `ember-cli`.

FastBoot reads `index.html` from dist folder so it doesn't care about the `rootUrl`.

cc: @stefanpenner @josemarluedke 