### PR TITLE
Enable running tests on Node 4, 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 ---
 language: node_js
 node_js:
-  # disabled while we refactor tests
-  # - "4"
+  - "4"
   - "6"
-  # - "7"
+  - "7"
 
 env:
   - CXX=g++-4.8 WORKER_COUNT=2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,10 +4,9 @@
 environment:
   MOCHA_REPORTER: "mocha-appveyor-reporter"
   matrix:
-    # disabled while we refactor tests
-    # - nodejs_version: "4"
+    - nodejs_version: "4"
     - nodejs_version: "6"
-    # - nodejs_version: "7"
+    - nodejs_version: "7"
 
 # Install scripts. (runs after repo cloning)
 install:


### PR DESCRIPTION
We disabled it while we were debugging `yarn` issues but forgot to enable it back.

cc: @stefanpenner 