### PR TITLE
Protocol double colon fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ export default Ember.Route.extend({
 
 ### Protocol
 
-You can access the protocol (`http` or `https`) of the request that the
+You can access the protocol (`http:` or `https:`) of the request that the
 current FastBoot server is responding to via `fastboot.request` in the
 `fastboot` service.
 

--- a/fastboot/initializers/ajax.js
+++ b/fastboot/initializers/ajax.js
@@ -6,7 +6,7 @@ const { get } = Ember;
 var nodeAjax = function(options) {
   let httpRegex = /^https?:\/\//;
   let protocolRelativeRegex = /^\/\//;
-  let protocol = get(this, 'fastboot.request.protocol') + ':';
+  let protocol = get(this, 'fastboot.request.protocol');
 
   if (protocolRelativeRegex.test(options.url)) {
     options.url = protocol + options.url;

--- a/test/request-details-test.js
+++ b/test/request-details-test.js
@@ -49,8 +49,8 @@ describe('request details', function() {
       }
     })
       .then(function(response) {
-        expect(response.body).to.contain('Protocol: http');
-        expect(response.body).to.contain('Protocol from Instance Initializer: http');
+        expect(response.body).to.contain('Protocol: http:');
+        expect(response.body).to.contain('Protocol from Instance Initializer: http:');
       });
   });
 


### PR DESCRIPTION
Hello! I'm opening this PR to start a discussion, so nevermind the lack of tests, I'm wiling to add them in case these changes make sense to the maintainers.

1. I'm not exactly sure why, but `request.protocol` is returning `http:` in our environment

    We're running the latest release versions of ember, ember-cli-fastboot, and fastboot-app-server.
    The node version is `6.11.1`. Also, here's relevant nginx config:

    ```
    location / {
      proxy_pass http://localhost:8081;
      proxy_set_header Host $host;
      proxy_set_header X-Real-IP $remote_addr;
      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
      proxy_set_header X-Forwarded-Proto $scheme;
    }
    ```

    Given the colon is appended in [ajax initializer](https://github.com/ember-fastboot/ember-cli-fastboot/blob/d7cb1b5766cf8057735cd9356b7a24ec57104b9e/fastboot/initializers/ajax.js#L9) and [documentation](https://github.com/ember-fastboot/ember-cli-fastboot#protocol) states the protocol is either `http` or `https` I assume this is a bug which needs to be addressed.

2. I believe fastboot should support `X-Forwarded-Proto` header

    The reason for that fastboot tries to do the best job of determining where to send API requests and protocol is an important part of that.

    In our use case, the fastboot/ember site _and_ API is accessible only with `https`. Given the fastboot server is running on `http` with nginx in front of it this presents a problem since API requests are also being sent over http. I know that in some simpler use cases you can specify the `host` in the adapter, but our situation is little tricky because the app is multi-tenant and it's served from arbitrary subdomains, and we want API requests to go to these exact subdomains. So supporting `X-Forwarded-Proto` seems to be the only way.

Please let me know if this makes sense. Thanks!