### PR TITLE
Remove deprecated API from fastboot service

### DIFF
--- a/app/services/fastboot.js
+++ b/app/services/fastboot.js
@@ -63,8 +63,6 @@ const Shoebox = Ember.Object.extend({
 });
 
 const FastBootService = Ember.Service.extend({
-  cookies: deprecatingAlias('request.cookies', { id: 'fastboot.cookies-to-request', until: '0.9.9' }),
-  headers: deprecatingAlias('request.headers', { id: 'fastboot.headers-to-request', until: '0.9.9' }),
   isFastBoot: typeof FastBoot !== 'undefined',
 
   init() {
@@ -75,12 +73,6 @@ const FastBootService = Ember.Service.extend({
   },
 
   host: computed(function() {
-    deprecate(
-      'Usage of fastboot service\'s `host` property is deprecated.  Please use `request.host` instead.',
-      false,
-      { id: 'fastboot.host-to-request', until: '0.9.9' }
-    );
-
     return this._fastbootInfo.request.host();
   }),
 


### PR DESCRIPTION
Removes some deprecations that were targeted for 0.9.9.

cc: @rwjblue @stefanpenner 