### PR TITLE
remove ember-cli-test-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-string-utils": "^1.0.0",
-    "ember-cli-test-loader": "^2.1.0",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "^2.11.0",
     "ember-disable-prototype-extensions": "^1.1.0",


### PR DESCRIPTION
this comes in via ember-cli-qunit now and isn't necessary