### PR TITLE
remove ember-cli-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "ember-cli-htmlbars-inline-precompile": "^1.0.2",
     "ember-cli-inject-live-reload": "^1.4.1",
     "ember-cli-qunit": "^3.1.0",
-    "ember-cli-release": "^0.2.9",
     "ember-cli-shims": "^1.0.2",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-string-utils": "^1.0.0",


### PR DESCRIPTION
Unless anyone is using this, it is just bringing in older dependencies.