### PR TITLE
Revert "reuse `FastBootExpressMiddleware`"

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,17 +106,17 @@ module.exports = {
 
     return tree;
   },
-
+  
   _processAddons(addons, fastbootTrees) {
     addons.forEach((addon) => {
       this._processAddon(addon, fastbootTrees);
     });
   },
-
+  
   _processAddon(addon, fastbootTrees) {
     // walk through each addon and grab its fastboot tree
     const currentAddonFastbootPath = path.join(addon.root, 'fastboot');
-
+    
     let fastbootTree;
     if (existsSync(currentAddonFastbootPath)) {
       fastbootTree = this.treeGenerator(currentAddonFastbootPath);
@@ -131,17 +131,17 @@ module.exports = {
     } else if (fastbootTree !== undefined) {
       fastbootTrees.push(fastbootTree);
     }
-
+    
     this._processAddons(addon.addons, fastbootTrees);
   },
-
+  
   /**
    * Function that builds the fastboot tree from all fastboot complaint addons
    * and project and transpiles it into appname-fastboot.js
    */
   _getFastbootTree() {
     const appName = this._name;
-
+    
     let fastbootTrees = [];
     this._processAddons(this.project.addons, fastbootTrees);
 
@@ -231,7 +231,7 @@ module.exports = {
     if (emberCliVersion.gte('2.12.0-beta.1')) {
       // only run the middleware when ember-cli version for app is above 2.12.0-beta.1 since
       // that version contains API to hook fastboot into ember-cli
-      let fastbootMiddleware;
+
       app.use((req, resp, next) => {
         const fastbootQueryParam = (req.query.hasOwnProperty('fastboot') && req.query.fastboot === 'false') ? false : true;
         const enableFastBootServe = !process.env.FASTBOOT_DISABLED && fastbootQueryParam;
@@ -247,11 +247,11 @@ module.exports = {
             this.fastboot = new FastBoot({
               distPath: outputPath
             });
-
-            fastbootMiddleware = FastBootExpressMiddleware({
-              fastboot: this.fastboot
-            });
           }
+
+          let fastbootMiddleware = FastBootExpressMiddleware({
+            fastboot: this.fastboot
+          });
 
           fastbootMiddleware(req, resp, next);
         } else {


### PR DESCRIPTION
This reverts commit 27388c22e0c0f9dcf816833db388ddb5759b05cf.

Fixes #478.

cc : @marcoow @kellyselden @rwjblue 