### PR TITLE
remove release.js from npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,4 @@
 /bower_components
-/config/release.js
 /dist
 /test
 /tests


### PR DESCRIPTION
file doesn't exist anymore