### PR TITLE
remove /fastboot-dist from git-ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 
 # compiled output
 /dist
-/fastboot-dist
 /tmp
 
 # dependencies


### PR DESCRIPTION
I think this is a legacy folder that is gone.

@kratiahuja can you confirm?