### PR TITLE
Allow to extend application FastBoot config via addon hook fastbootConfigTree

### DIFF
--- a/lib/broccoli/fastboot-config.js
+++ b/lib/broccoli/fastboot-config.js
@@ -2,7 +2,8 @@
 
 const fs     = require('fs');
 const fmt    = require('util').format;
-const uniq   = require('lodash.uniq');
+const uniq   = require('ember-cli-lodash-subset').uniq;
+const merge  = require('ember-cli-lodash-subset').merge;
 const md5Hex = require('md5-hex');
 const path   = require('path');
 const Plugin = require('broccoli-plugin');
@@ -94,7 +95,7 @@ module.exports = class FastBootConfig extends Plugin {
           throw new Error('`fastbootConfigTree` requires a map to be returned');
         }
 
-        Object.assign(this.fastbootConfig, configFromAddon);
+        merge(this.fastbootConfig, configFromAddon);
       }
     });
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "broccoli-plugin": "^1.2.1",
     "chalk": "^2.0.1",
     "ember-cli-babel": "^6.7.2",
-    "ember-cli-lodash-subset": "^2.0.0",
+    "ember-cli-lodash-subset": "2.0.1",
     "ember-cli-version-checker": "^2.0.0",
     "fastboot": "^1.1.0",
     "fastboot-express-middleware": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
     "broccoli-plugin": "^1.2.1",
     "chalk": "^2.0.1",
     "ember-cli-babel": "^6.7.2",
+    "ember-cli-lodash-subset": "^2.0.0",
     "ember-cli-version-checker": "^2.0.0",
     "fastboot": "^1.1.0",
     "fastboot-express-middleware": "^1.1.0",
     "fs-extra": "^4.0.0",
     "json-stable-stringify": "^1.0.1",
-    "lodash.uniq": "^4.2.0",
     "md5-hex": "^2.0.0",
     "silent-error": "^1.0.0"
   },

--- a/test/fixtures/fastboot-config/README.md
+++ b/test/fixtures/fastboot-config/README.md
@@ -1,0 +1,1 @@
+This fixture app has an addon that implements fastbootConfigTree that extends application config in FastBoot build.

--- a/test/fixtures/fastboot-config/config/environment.js
+++ b/test/fixtures/fastboot-config/config/environment.js
@@ -1,0 +1,51 @@
+/* jshint node: true */
+
+module.exports = function(environment) {
+  var ENV = {
+    modulePrefix: 'fastboot-config',
+    environment: environment,
+    baseURL: '/',
+    locationType: 'auto',
+    EmberENV: {
+      FEATURES: {
+        // Here you can enable experimental features on an ember canary build
+        // e.g. 'with-controller': true
+      }
+    },
+
+    APP: {
+      // Here you can pass flags/options to your application instance
+      // when it is created
+    },
+
+    fastboot: {
+      hostWhitelist: ['example.com', 'subdomain.example.com', /localhost:\d+/]
+    }
+  };
+
+  if (environment === 'development') {
+    // ENV.APP.LOG_RESOLVER = true;
+    // ENV.APP.LOG_ACTIVE_GENERATION = true;
+    // ENV.APP.LOG_TRANSITIONS = true;
+    // ENV.APP.LOG_TRANSITIONS_INTERNAL = true;
+    // ENV.APP.LOG_VIEW_LOOKUPS = true;
+  }
+
+  if (environment === 'test') {
+    // Testem prefers this...
+    ENV.baseURL = '/';
+    ENV.locationType = 'none';
+
+    // keep test console output quieter
+    ENV.APP.LOG_ACTIVE_GENERATION = false;
+    ENV.APP.LOG_VIEW_LOOKUPS = false;
+
+    ENV.APP.rootElement = '#ember-testing';
+  }
+
+  if (environment === 'production') {
+
+  }
+
+  return ENV;
+};

--- a/test/fixtures/fastboot-config/ember-cli-build.js
+++ b/test/fixtures/fastboot-config/ember-cli-build.js
@@ -1,0 +1,6 @@
+module.exports = function(defaults) {
+  var EmberApp = require('ember-cli/lib/broccoli/ember-app');
+  var app = new EmberApp(defaults, {});
+
+  return app.toTree();
+};

--- a/test/fixtures/fastboot-config/node_modules/fake-addon-2/index.js
+++ b/test/fixtures/fastboot-config/node_modules/fake-addon-2/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: "Fake Addon"
+};

--- a/test/fixtures/fastboot-config/node_modules/fake-addon-2/package.json
+++ b/test/fixtures/fastboot-config/node_modules/fake-addon-2/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fake-addon-2",
+  "version": "0.1.0",
+  "ember-addon": {
+    "fastbootDependencies": ["bar", "baz", "path"]
+  },
+  "dependencies": {
+    "bar": "^0.1.2",
+    "baz": "0.0.0"
+  },
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/test/fixtures/fastboot-config/node_modules/fake-addon/index.js
+++ b/test/fixtures/fastboot-config/node_modules/fake-addon/index.js
@@ -1,0 +1,11 @@
+module.exports = {
+  name: "Fake Addon",
+
+  fastbootConfigTree() {
+    return {
+      [this.app.name]: {
+        'foo': 'bar'
+      }
+    }
+  }
+};

--- a/test/fixtures/fastboot-config/node_modules/fake-addon/package.json
+++ b/test/fixtures/fastboot-config/node_modules/fake-addon/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "fake-addon",
+  "version": "0.1.0",
+  "ember-addon": {
+    "fastbootDependencies": ["path", "foo", "bar"]
+  },
+  "dependencies": {
+    "foo": "1.0.0",
+    "bar": "^0.1.2"
+  },
+  "keywords": [
+    "ember-addon"
+  ]
+}

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -84,6 +84,12 @@ describe('generating package.json', function() {
       ]);
     });
 
+    it('contains app name', function() {
+      let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
+
+      expect(pkg.fastboot.appName).to.equal('module-whitelist');
+    });
+
     it('contains the application config', function() {
       let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
 
@@ -138,12 +144,6 @@ describe('generating package.json', function() {
           exportApplicationGlobal: true
         });
       });
-    });
-
-    it('contains app name', function() {
-      let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
-
-      expect(pkg.fastboot.appName).to.equal('module-whitelist');
     });
   });
 

--- a/test/package-json-test.js
+++ b/test/package-json-test.js
@@ -99,15 +99,50 @@ describe('generating package.json', function() {
       });
     });
 
-    it('contains additional config from addons', function() {
+    it('contains additional config from ember-fastboot-build-example addon', function() {
       let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
 
       expect(pkg.fastboot.config['foo']).to.equal('bar');
     });
 
+    describe('with addon that implements fastbootConfigTree', function() {
+      let app;
+
+      before(function() {
+        app = new AddonTestApp();
+
+        return app.create('fastboot-config', {
+          skipNpm: true
+        })
+          .then(addFastBootDeps)
+          .then(function() {
+            return app.run('npm', 'install');
+          })
+          .then(function() {
+            return app.runEmberCommand('build');
+          });
+      });
+
+      it('it extends the application config', function() {
+        let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
+
+        expect(pkg.fastboot.config['fastboot-config']).to.deep.equal({
+          foo: 'bar',
+          modulePrefix: 'fastboot-config',
+          environment: 'development',
+          baseURL: '/',
+          locationType: 'auto',
+          EmberENV: { FEATURES: {} },
+          APP: { name: 'fastboot-config', version: '0.0.0+', autoboot: false },
+          fastboot: { hostWhitelist: [ 'example.com', 'subdomain.example.com', '/localhost:\\d+/' ] },
+          exportApplicationGlobal: true
+        });
+      });
+    });
+
     it('contains app name', function() {
       let pkg = fs.readJsonSync(app.filePath('dist/package.json'));
-      
+
       expect(pkg.fastboot.appName).to.equal('module-whitelist');
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,6 +2161,10 @@ ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
 
+ember-cli-lodash-subset@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.0.tgz#d985b12fdc45f5c6996cb5f4c205f55de5550120"
+
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-normalize-entity-name/-/ember-cli-normalize-entity-name-1.0.0.tgz#0b14f7bcbc599aa117b5fddc81e4fd03c4bad5b7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2157,13 +2157,13 @@ ember-cli-legacy-blueprints@^0.1.2:
     rsvp "^3.0.17"
     silent-error "^1.0.0"
 
+ember-cli-lodash-subset@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.1.tgz#20cb68a790fe0fde2488ddfd8efbb7df6fe766f2"
+
 ember-cli-lodash-subset@^1.0.11, ember-cli-lodash-subset@^1.0.7:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-1.0.12.tgz#af2e77eba5dcb0d77f3308d3a6fd7d3450f6e537"
-
-ember-cli-lodash-subset@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ember-cli-lodash-subset/-/ember-cli-lodash-subset-2.0.0.tgz#d985b12fdc45f5c6996cb5f4c205f55de5550120"
 
 ember-cli-normalize-entity-name@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Use lodash.merge provided by `ember-cli-lodash-subset` instead of Object.assign for deep merge

Added new app fixture `fastboot-config` that copied from `module-whitelist`.
Implemented `fastbootConfigTree` hook in `test/fixtures/fastboot-config/node_modules/fake-addon/index.js` that extends application config to check for a regression and fix actually works.