### PR TITLE
Allow reading sandbox and sandboxGlobals from app's config/environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ember-cli-fastboot changelog
 
+## Unreleased
+
+### Added
+* allow reading sandboxGlobals from app's config/environment
+
 ## 1.1.0
 
 * Bumping `fastboot-express-middleware` to 1.1.0

--- a/index.js
+++ b/index.js
@@ -292,6 +292,8 @@ module.exports = {
   serverMiddleware(options) {
     let emberCliVersion = this._getEmberCliVersion();
     let app = options.app;
+    let appConfig = this._getHostAppConfig();
+    let fastbootConfig = appConfig.fastboot;
 
     if (emberCliVersion.gte('2.12.0-beta.1')) {
       // only run the middleware when ember-cli version for app is above 2.12.0-beta.1 since
@@ -310,7 +312,8 @@ module.exports = {
             // and custom sandbox class
             this.ui.writeLine(chalk.green('App is being served by FastBoot'));
             this.fastboot = new FastBoot({
-              distPath: outputPath
+              distPath: outputPath,
+              sandboxGlobals: fastbootConfig && fastbootConfig.sandboxGlobals
             });
           }
 

--- a/index.js
+++ b/index.js
@@ -293,7 +293,6 @@ module.exports = {
     let emberCliVersion = this._getEmberCliVersion();
     let app = options.app;
     let appConfig = this._getHostAppConfig();
-    let fastbootConfig = appConfig.fastboot;
 
     if (emberCliVersion.gte('2.12.0-beta.1')) {
       // only run the middleware when ember-cli version for app is above 2.12.0-beta.1 since
@@ -308,12 +307,12 @@ module.exports = {
         if (req.serveUrl && enableFastBootServe) {
           // if it is a base page request, then have fastboot serve the base page
           if (!this.fastboot) {
-            // TODO(future): make this configurable for allowing apps to pass sandboxGlobals
-            // and custom sandbox class
+            let fastbootConfig = appConfig.fastboot || {};
             this.ui.writeLine(chalk.green('App is being served by FastBoot'));
             this.fastboot = new FastBoot({
               distPath: outputPath,
-              sandboxGlobals: fastbootConfig && fastbootConfig.sandboxGlobals
+              sandbox: fastbootConfig.sandbox,
+              sandboxGlobals: fastbootConfig.sandboxGlobals
             });
           }
 


### PR DESCRIPTION
This PR addresses this TODO:

https://github.com/ember-fastboot/ember-cli-fastboot/blob/6336e97857ebfdc19f4452cd9f4a8d38ed45c331/index.js#L309-L310

So far the only way I've been able to get my addon to work is by passing `sandboxGlobals` to the `FastBoot` constructor (see https://github.com/ember-fastboot/fastboot/issues/175).

The way I've achieved that is by adding a `sandboxGlobals` property to the `fastboot` hash in the app's config/environment:

```js
// app's config/environment.js
module.exports = function(environment) {
  let ENV = {
    fastboot: {
      sandboxGlobals: {
        requireFunctionName: 'equireray'
      }
    }
  };
  return ENV;
};
```

Then w/ the changes in this PR I'm able to pass those along to `FastBoot()`.

I only did it this way b/c it was the most expedient way to solve my problem, and I recognize that there might be a better way to pass these along. For this reason I stopped once I got it working and thought I'd check to see if you think I'm taking the best approach before investing in tests, adding docs to the README, etc.

I can confirm this does pass the `sandboxGlobals` param by running this from my app via `npm link`, but I did not try testing the `sanbox` parameter b/c I am not really sure of a valid use case for that. Also tests pass locally, but I did not add any tests b/c it was not obvious to me how I should test this feature.

Let me know if you think this is the right way to go about this, and if you'd like me to add tests to this PR, please point me in the right direction.

