### PR TITLE
Move fastboot-transform and fs-extra to dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "ember-cli-version-checker": "^2.0.0",
     "fastboot": "^1.1.0",
     "fastboot-express-middleware": "^1.1.0",
+    "fastboot-transform": "^0.1.2",
+    "fs-extra": "^4.0.2",
     "json-stable-stringify": "^1.0.1",
     "md5-hex": "^2.0.0",
     "silent-error": "^1.0.0"
@@ -58,8 +60,6 @@
     "ember-resolver": "^4.3.0",
     "ember-sinon": "^1.0.0",
     "ember-source": "~2.16.0",
-    "fastboot-transform": "^0.1.2",
-    "fs-extra": "^4.0.0",
     "glob": "^7.0.0",
     "loader.js": "^4.2.3",
     "mocha": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -189,6 +189,13 @@ array-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
 
+array-events@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/array-events/-/array-events-0.2.0.tgz#ff42ac53e66f485d6f883234c32252bc2286130e"
+  dependencies:
+    async-arrays "*"
+    extended-emitter "*"
+
 array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
@@ -248,6 +255,12 @@ assertion-error@^1.0.1:
 ast-types@0.9.6:
   version "0.9.6"
   resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+
+async-arrays@*:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/async-arrays/-/async-arrays-1.0.1.tgz#347af2b70f2a7a5767a2d5679cc42bbf1c220fd9"
+  dependencies:
+    sift "*"
 
 async-disk-cache@^1.2.1:
   version "1.3.3"
@@ -852,11 +865,11 @@ binary-extensions@^1.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/binaryextensions/-/binaryextensions-2.0.0.tgz#e597d1a7a6a3558a2d1c7241a16c99965e6aa40f"
 
-bit-mask@0.0.2-alpha:
-  version "0.0.2-alpha"
-  resolved "https://registry.yarnpkg.com/bit-mask/-/bit-mask-0.0.2-alpha.tgz#42880fa80055151165d5fa15b331bc0459c27372"
+bit-mask@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/bit-mask/-/bit-mask-1.0.1.tgz#d7cf212bde6e2dcc0503faab50941e4eb289a6f5"
   dependencies:
-    prime "0.0.5-alpha"
+    array-events "0.2.0"
 
 blank-object@^1.0.1:
   version "1.0.2"
@@ -1441,11 +1454,11 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chai-fs@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/chai-fs/-/chai-fs-1.0.0.tgz#8b242852748a54f1df91f1ea430bb39748cf7421"
+chai-fs@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/chai-fs/-/chai-fs-2.0.0.tgz#35ae039fbbb0710f5122aae17faba1e8f41107c6"
   dependencies:
-    bit-mask "0.0.2-alpha"
+    bit-mask "^1.0.1"
     readdir-enhanced "^1.4.0"
 
 chai@^4.1.0:
@@ -2684,6 +2697,13 @@ extend-shallow@^2.0.1:
 extend@^3.0.0, extend@~3.0.0, extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
+
+extended-emitter@*:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/extended-emitter/-/extended-emitter-1.0.2.tgz#a2521ab93f3b1b69a35ff3a35da9889385a99ba0"
+  dependencies:
+    sift "*"
+    wolfy87-eventemitter "*"
 
 external-editor@^1.1.0:
   version "1.1.1"
@@ -4933,10 +4953,6 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prime@0.0.5-alpha:
-  version "0.0.5-alpha"
-  resolved "https://registry.yarnpkg.com/prime/-/prime-0.0.5-alpha.tgz#e4d49a657bed2eb30e513adc6e5dfb83622e90c1"
-
 printf@^0.2.3:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.2.5.tgz#c438ca2ca33e3927671db4ab69c0e52f936a4f0f"
@@ -5438,6 +5454,10 @@ shebang-regex@^1.0.0:
 shellwords@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.1.tgz#d6b9181c1a48d397324c84871efbcfc73fc0654b"
+
+sift@*:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/sift/-/sift-5.0.0.tgz#212ecb410d8a51b83e7d969e49d53e6590285ffa"
 
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
@@ -6203,6 +6223,10 @@ winston@*:
     eyes "0.1.x"
     isstream "0.1.x"
     stack-trace "0.0.x"
+
+wolfy87-eventemitter@*:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/wolfy87-eventemitter/-/wolfy87-eventemitter-5.2.4.tgz#5021d2952d3611cbcd195149711d9b595cd11d48"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
A follow up for https://github.com/ember-fastboot/ember-cli-fastboot/pull/470#discussion_r152219029