### PR TITLE
Fix package.json, make ember-cli-preprocess-registry an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "chalk": "^2.0.1",
     "ember-cli-babel": "^6.7.2",
     "ember-cli-lodash-subset": "2.0.1",
+    "ember-cli-preprocess-registry": "^3.1.1",
     "ember-cli-version-checker": "^2.0.0",
     "fastboot": "^1.1.0",
     "fastboot-express-middleware": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2131,7 +2131,7 @@ ember-cli-path-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/ember-cli-path-utils/-/ember-cli-path-utils-1.0.0.tgz#4e39af8b55301cddc5017739b77a804fba2071ed"
 
-ember-cli-preprocess-registry@^3.1.0:
+ember-cli-preprocess-registry@^3.1.0, ember-cli-preprocess-registry@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/ember-cli-preprocess-registry/-/ember-cli-preprocess-registry-3.1.1.tgz#38456c21c4d2b64945850cf9ec68db6ba769288a"
   dependencies:


### PR DESCRIPTION
Had some issues with this, in `ember-cli-addon-tests` based tests with npm 5 at least. Got `Cannot find module 'ember-cli-preprocess-registry/preprocessors'`, from this [line](https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/index.js#L18).

Probably works in most cases, because `ember-cli` brings in this dependency, but AFAIK we cannot rely on npm putting this into the root `node_modules` (deduping it), as long as we don't state an explicit dependency on it.