### PR TITLE
Utilize rehydration serialization from glimmer

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,8 @@ it to know whether or not the DOM it received in the browser side was generated
 by the serialization builder.  If it was, it tells the Ember.js Application to
 use the rehydration builder and your application will be using rehydration.
 
+Rehydration is only compatible with fastboot > 1.1.4, and Ember.js > 3.2.
+
 ## Build Hooks for FastBoot
 
 ### Disabling incompatible dependencies

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ it to know whether or not the DOM it received in the browser side was generated
 by the serialization builder.  If it was, it tells the Ember.js Application to
 use the rehydration builder and your application will be using rehydration.
 
-Rehydration is only compatible with fastboot > 1.1.4, and Ember.js > 3.2.
+Rehydration is only compatible with fastboot > 1.1.4-beta.1, and Ember.js > 3.2.
 
 ## Build Hooks for FastBoot
 

--- a/README.md
+++ b/README.md
@@ -399,6 +399,41 @@ export default  Ember.Route.extend({
 ```
 And they still take advantage of caching in the `shoebox`. No more redundant AJAX for already acquired data. Installation details are available in the addon [README](https://github.com/appchance/ember-cached-shoe#ember-cached-shoe).
 
+### Rehydration
+
+What is Rehydration?
+
+The rehydration feature means that the Glimmer VM can take a DOM tree
+created using Server Side Rendering (SSR) and use it as the starting
+point for the append pass.
+
+See details here:
+
+https://github.com/glimmerjs/glimmer-vm/commit/316805b9175e01698120b9566ec51c88d075026a
+
+In order to utilize rehydration in Ember.js applications we need to ensure that
+both server side renderers (like fastboot) properly encode the DOM they send to
+the browser with the serialization format (introduced in the commit above) AND
+that the browser instantiated Ember.js application knows to use the rehydration
+builder to consume that DOM.
+
+Rehydration is 100% opt-in, if you do not specify the environment flag your
+application will behave as it did before!
+
+We can opt-in to the rehydration filter by setting the following environment
+flag:
+
+```
+EXPERIMENTAL_RENDER_MODE_SERIALIZE=true
+```
+
+This flag is read by Ember CLI Fastboot's dependency; fastboot to alert it to
+produce DOM with the glimmer-vm's serialization element builder.  This addon
+(Ember CLI Fastboot) then uses a utility function from glimmer-vm that allows
+it to know whether or not the DOM it received in the browser side was generated
+by the serialization builder.  If it was, it tells the Ember.js Application to
+use the rehydration builder and your application will be using rehydration.
+
 ## Build Hooks for FastBoot
 
 ### Disabling incompatible dependencies

--- a/index.js
+++ b/index.js
@@ -58,6 +58,7 @@ module.exports = {
       app.options.fingerprint.generateAssetMap = true;
     }
 
+    app.import('vendor/experimental-render-mode-rehydrate.js');
     // get the app registry object and app name so that we can build the fastboot
     // tree
     this._appRegistry = app.registry;

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-lodash-subset": "2.0.1",
     "ember-cli-preprocess-registry": "^3.1.0",
     "ember-cli-version-checker": "^2.1.0",
-    "fastboot": "github:rondale-sc/fastboot#utilize-rehydration-serialization-from-glimmer",
+    "fastboot": "^1.1.4-beta.1",
     "fastboot-express-middleware": "^1.1.0",
     "fastboot-transform": "^0.1.2",
     "fs-extra": "^4.0.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-lodash-subset": "2.0.1",
     "ember-cli-preprocess-registry": "^3.1.0",
     "ember-cli-version-checker": "^2.1.0",
-    "fastboot": "^1.1.3",
+    "fastboot": "github:rondale-sc/fastboot#utilize-rehydration-serialization-from-glimmer",
     "fastboot-express-middleware": "^1.1.0",
     "fastboot-transform": "^0.1.2",
     "fs-extra": "^4.0.2",

--- a/vendor/experimental-render-mode-rehydrate.js
+++ b/vendor/experimental-render-mode-rehydrate.js
@@ -2,7 +2,11 @@
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
 
-    if (current && Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)) {
+    if (
+      current &&
+      typeof Ember.ViewUtils.isSerializationFirstNode === 'function' &&
+      Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)
+    ) {
       Ember.ApplicationInstance.reopen({
         _bootSync: function(options) {
           if (options === undefined) {

--- a/vendor/experimental-render-mode-rehydrate.js
+++ b/vendor/experimental-render-mode-rehydrate.js
@@ -1,0 +1,25 @@
+(function() {
+  if (typeof FastBoot === 'undefined') {
+    var current = document.getElementById('fastboot-body-start');
+
+    if (current && current.nextSibling.nodeValue === '%+b:0%') {
+      Ember.ApplicationInstance.reopen({
+        _bootSync: function(options) {
+          if (options === undefined) {
+            options = {
+              _renderMode: 'rehydrate'
+            };
+          }
+
+          return this._super(options);
+        }
+      });
+
+      // Prevent clearRender  by removing `fastboot-body-start` which is already
+      // guarded for
+      current.parentNode.removeChild(current);
+      var end = document.getElementById('fastboot-body-end');
+      end.parentNode.removeChild(end);
+    }
+  }
+})();

--- a/vendor/experimental-render-mode-rehydrate.js
+++ b/vendor/experimental-render-mode-rehydrate.js
@@ -2,7 +2,7 @@
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
 
-    if (current && current.nextSibling.nodeValue === '%+b:0%') {
+    if (current && Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)) {
       Ember.ApplicationInstance.reopen({
         _bootSync: function(options) {
           if (options === undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,9 +2865,9 @@ fastboot@^1.1.2:
     simple-dom "^1.0.0"
     source-map-support "^0.5.0"
 
-fastboot@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-1.1.3.tgz#56c5f56415c5ae8de2db539c0d3ecbcd65538f8b"
+fastboot@^1.1.4-beta.1:
+  version "1.1.4-beta.1"
+  resolved "https://registry.yarnpkg.com/fastboot/-/fastboot-1.1.4-beta.1.tgz#860f8af2bd032b3a7477fdf6e1a64b034a02829f"
   dependencies:
     chalk "^2.0.1"
     cookie "^0.3.1"


### PR DESCRIPTION
This is part of an arching plan to introduce Glimmer's
rehydration/serializtion modes to Ember proper.

There are 4 PR's that are all interwoven, of which, this is one.

- [x] Glimmer.js: glimmerjs/glimmer-vm#783 (comment)
- [x] Ember.js: emberjs/ember.js#16227
- [x] Fastboot: ember-fastboot/fastboot#185
- [ ] EmberCLI Fastboot: ember-fastboot/ember-cli-fastboot#580

In order of need to land they are:

Glimmer.js:
glimmerjs/glimmer-vm#783 (comment)

This resolves a rather intimate API problem.  Glimmer-vm expects a very
specific comment node to exist to know whether or not the rehydration
element builder can do it's job properly.  If it is not found on the
first node from `rootElement` it throws.

In fastboot however we are certain that there will already be existant
elements in the way that will happen before rendered content.

This PR just iterates through the nodes until it finds the expected
comment node.  And only throws if it never finds one.

---

Ember.js:
emberjs/ember.js#16227

This PR modifies the `visit` API to allow a private _renderMode to be
set to either serialize or rehydrate.  In SSR environments the
assumption (as it is here in this fastboot PR) is that we'll set the
visit API to serialize mode which ensures glimmer-vm's serialize element
builder is used to build the API.

The serialize element builder ensures that we have the necessary fidelty
to rehydrate correctly and is mandatory input for rehydration.

---

Fastboot:
ember-fastboot/fastboot#185

This allows enviroment variable to set _renderMode to be used in Visit
API.  Fastboot must send content to browser made with the serialization
element builder to ensure rehydration can be sucessful.

---

EmberCLI Fastboot:
ember-fastboot/ember-cli-fastboot#580

Finally this does the fun part of disabling the current
clear-double-render instance-initializer

We first check to ensure we are in a non-fastboot environment.  Then we
ensure that we can find the expected comment node from glimmer-vm's
serialize element builder.  This ensures that this change will only
effect peoeple who use ember-cli-fastboot with the serialized output
from the currently experimental fastboot setup

Then we ensure `ApplicationInstance#_bootSync` specifies the rehydrate
_renderMode.

This is done in `_bootSync` this way because visit is currently not used
to boot ember applications.  And we must instead set bootOptions this
way instead.

We also remove the markings for `fastboot-body-start` and
`fastboot-body-end` to ensure clear-double render instance-initializer
is never called.