### PR TITLE
[DOC] Fix deprecated on node debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ about debug mode: it makes everything much slower.
 node --inspect-brk ./node_modules/.bin/ember serve
 ```
 
-This starts the FastBoot server in debug mode. Note that the `--debug-brk` flag will cause your
+This starts the FastBoot server in debug mode. Note that the `--inspect-brk` flag will cause your
 app to start paused to give you a chance to open the debugger.
 
 Once you see the output `Debugger listening on ws://127.0.0.1:<port>/<guid>`, open Chrome

--- a/README.md
+++ b/README.md
@@ -569,7 +569,7 @@ First let's start up the FastBoot server with Node in debug mode. One thing
 about debug mode: it makes everything much slower.
 
 ```sh
-node --debug-brk --inspect ./node_modules/.bin/ember serve
+node --inspect-brk ./node_modules/.bin/ember serve
 ```
 
 This starts the FastBoot server in debug mode. Note that the `--debug-brk` flag will cause your


### PR DESCRIPTION
Fix this: `(node:10790) [DEP0062] DeprecationWarning: `node --inspect --debug-brk` is deprecated. Please use `node --inspect-brk` instead.`