### PR TITLE
Fix tests

### DIFF
--- a/test/root-url-test.js
+++ b/test/root-url-test.js
@@ -63,7 +63,7 @@ describe('rootUrl acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });

--- a/test/serve-assets-test.js
+++ b/test/serve-assets-test.js
@@ -30,7 +30,7 @@ describe('serve assets acceptance', function() {
     return request('http://localhost:49741/assets/vendor.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
         expect(response.body).to.contain("Ember =");
       });
   });
@@ -39,7 +39,7 @@ describe('serve assets acceptance', function() {
     return request('http://localhost:49741/assets/dummy.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
         expect(response.body).to.contain("this.route('posts')");
       });
   });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -63,7 +63,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });
@@ -92,7 +92,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });
@@ -131,7 +131,7 @@ describe('simple acceptance', function() {
       .then(function(response) {
         // Asset serving is on by default
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
         expect(response.body).to.contain("Ember =");
       });
   });
@@ -141,7 +141,7 @@ describe('simple acceptance', function() {
       .then(function(response) {
         // Asset serving is on by default
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=UTF-8");
+        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
         expect(response.body).to.not.contain("autoBoot: false");
       });
   });


### PR DESCRIPTION
It is unknown right now as to why these are suddenly lowercase, this
directly reverts a change from about a year ago by Stef.

https://github.com/ember-fastboot/ember-cli-fastboot/commit/67102c964e6b276e3f318f01eca56944fe337e3c#diff-c2a8324c5e490c750018e7ed31eb42e9

Previously somewhere in our middleware stack upcased the `UTF-8` portion
of the Content Type header this doesn't seem to be happening anymore.

This fix seems innocuous for now.  Perhaps worth investigation later.