### PR TITLE
Use case-insensitive matching when comparing content-type

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "broccoli-test-helper": "^1.1.0",
     "chai": "^4.1.0",
     "chai-fs": "^2.0.0",
+    "chai-string": "^1.4.0",
     "co": "^4.6.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "~3.0.0",

--- a/test/custom-html-file-test.js
+++ b/test/custom-html-file-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const expect = require('chai').use(require('chai-string')).expect;
 const RSVP = require('rsvp');
 const request = RSVP.denodeify(require('request'));
 
@@ -35,7 +35,7 @@ describe('custom htmlFile', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
 
         expect(response.body).to.contain("<title>custom index</title>");
         expect(response.body).to.contain("<h1>application template</h1>");

--- a/test/head-content-test.js
+++ b/test/head-content-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const expect = require('chai').use(require('chai-string')).expect;
 const RSVP = require('rsvp');
 const request = RSVP.denodeify(require('request'));
 
@@ -37,7 +37,7 @@ describe('head content acceptance', function() {
       }})
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain('<meta property="og:title" content="Head Data Title">');
         expect(response.body).to.not.contain('<!-- EMBER_CLI_FASTBOOT_HEAD -->');
       });

--- a/test/root-url-test.js
+++ b/test/root-url-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const expect = require('chai').use(require('chai-string')).expect;
 const RSVP = require('rsvp');
 const request = RSVP.denodeify(require('request'));
 
@@ -35,7 +35,7 @@ describe('rootUrl acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("Welcome to Ember.js");
       });
   });
@@ -49,7 +49,7 @@ describe('rootUrl acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("Welcome to Ember.js");
       });
   });
@@ -63,7 +63,7 @@ describe('rootUrl acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });

--- a/test/serve-assets-test.js
+++ b/test/serve-assets-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const expect = require('chai').use(require('chai-string')).expect;
 const RSVP = require('rsvp');
 const request = RSVP.denodeify(require('request'));
 
@@ -30,7 +30,7 @@ describe('serve assets acceptance', function() {
     return request('http://localhost:49741/assets/vendor.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("application/javascript; charset=utf-8");
         expect(response.body).to.contain("Ember =");
       });
   });
@@ -39,7 +39,7 @@ describe('serve assets acceptance', function() {
     return request('http://localhost:49741/assets/dummy.js')
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("application/javascript; charset=utf-8");
         expect(response.body).to.contain("this.route('posts')");
       });
   });

--- a/test/simple-test.js
+++ b/test/simple-test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const expect = require('chai').expect;
+const expect = require('chai').use(require('chai-string')).expect;
 const RSVP = require('rsvp');
 const request = RSVP.denodeify(require('request'));
 
@@ -35,7 +35,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("Welcome to Ember.js");
       });
   });
@@ -49,7 +49,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("Welcome to Ember.js");
       });
   });
@@ -63,7 +63,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });
@@ -77,7 +77,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("Welcome to Ember.js");
         expect(response.body).to.contain("Posts Route!");
       });
@@ -92,7 +92,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("<!-- EMBER_CLI_FASTBOOT_BODY -->");
       });
   });
@@ -106,7 +106,7 @@ describe('simple acceptance', function() {
     })
       .then(function(response) {
         expect(response.statusCode).to.equal(500);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("BOOM");
       });
   });
@@ -121,7 +121,7 @@ describe('simple acceptance', function() {
       .then(function(response) {
         console.log(response.body);
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("text/html; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("text/html; charset=utf-8");
         expect(response.body).to.contain("FastBoot compatible vendor file: FastBoot default default value");
       });
   });
@@ -131,7 +131,7 @@ describe('simple acceptance', function() {
       .then(function(response) {
         // Asset serving is on by default
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("application/javascript; charset=utf-8");
         expect(response.body).to.contain("Ember =");
       });
   });
@@ -141,7 +141,7 @@ describe('simple acceptance', function() {
       .then(function(response) {
         // Asset serving is on by default
         expect(response.statusCode).to.equal(200);
-        expect(response.headers["content-type"]).to.eq("application/javascript; charset=utf-8");
+        expect(response.headers["content-type"]).to.equalIgnoreCase("application/javascript; charset=utf-8");
         expect(response.body).to.not.contain("autoBoot: false");
       });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1497,6 +1497,10 @@ chai-fs@^2.0.0:
     bit-mask "^1.0.1"
     readdir-enhanced "^1.4.0"
 
+chai-string@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/chai-string/-/chai-string-1.4.0.tgz#359140c051d36a4e4b1a5fc6b910152f438a8d49"
+
 chai@^4.1.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chai/-/chai-4.1.2.tgz#0f64584ba642f0f2ace2806279f4f06ca23ad73c"


### PR DESCRIPTION
See #583

The "charset=utf-8" in content-type sometimes changes in tests depending
on what express middleware serves the response.

The charset value is case-insensitive according to IANA (see:
https://www.iana.org/assignments/character-sets/character-sets.xhtml)

This adds chai-string (http://chaijs.com/plugins/chai-string/) as a devDep and
uses its `equalIgnoreCase` matcher in tests that check the value of
the content-type header.