### PR TITLE
Skip shoebox elements when clearing pre-rendered elements

### DIFF
--- a/addon/instance-initializers/clear-double-boot.js
+++ b/addon/instance-initializers/clear-double-boot.js
@@ -10,13 +10,14 @@ export function clearHtml() {
   let current = document.getElementById('fastboot-body-start');
   if (current) {
     let endMarker = document.getElementById('fastboot-body-end');
+    let shoeboxNodes = document.querySelectorAll('[type="fastboot/shoebox"]');
     let parent = current.parentElement;
     let nextNode;
     do {
       nextNode = current.nextSibling;
       parent.removeChild(current);
       current = nextNode;
-    } while (nextNode && nextNode !== endMarker);
+    } while (nextNode && nextNode !== endMarker && !Array.from(shoeboxNodes).includes(nextNode));
     parent.removeChild(endMarker);
   }
 }


### PR DESCRIPTION
Addresses the shoebox issue described in https://github.com/ember-fastboot/ember-cli-fastboot/issues/565#issuecomment-430364978.