### PR TITLE
Fix ember deprecation warning for Ember.Logger

### DIFF
--- a/fastboot/initializers/error-handler.js
+++ b/fastboot/initializers/error-handler.js
@@ -8,12 +8,12 @@ import Ember from 'ember';
 export default {
   name: 'error-handler',
 
-  initialize: function(application) {
+  initialize: function() {
     if (!Ember.onerror) {
       // if no onerror handler is defined, define one for fastboot environments
       Ember.onerror = function(err) {
-        let errorMessage = `There was an error running your app in fastboot. More info about the error: \n ${err.stack || err}`;
-        Ember.Logger.error(errorMessage);
+        const errorMessage = `There was an error running your app in fastboot. More info about the error: \n ${err.stack || err}`;
+        console.error(errorMessage);
       }
     }
   }


### PR DESCRIPTION
This is a fix for issue https://github.com/ember-fastboot/ember-cli-fastboot/issues/691.

When an error is thrown in `fastboot` (serverside), the `fastboot` [error-handler.js](https://github.com/ember-fastboot/ember-cli-fastboot/blob/efbebad3f9278e4b8179f720579f6eeee1fe8457/fastboot/initializers/error-handler.js#L16) uses `Ember.Logger.error()` to log the error to the terminal console. There is a deprecation warning for `Ember.Logger` that asks for `console` to be used instead:

`DEPRECATION: Use of Ember.Logger is deprecated. Please use 'console' for logging.`

**Fix**:
This PR replaces `Ember.Logger.error` with `console.error` 