### PR TITLE
Terrible, Awful, No Good, Very Bad Markup Crashes App

### DIFF
--- a/addon/instance-initializers/clear-double-boot.js
+++ b/addon/instance-initializers/clear-double-boot.js
@@ -22,7 +22,7 @@ export function clearHtml() {
       parent.removeChild(current);
       current = nextNode;
     } while (nextNode && nextNode !== endMarker && shoeboxNodesArray.indexOf(nextNode) < 0);
-    parent.removeChild(endMarker);
+    endMarker.parentElement.removeChild(endMarker);
   }
 }
 export default {

--- a/tests/integration/instance-initializers/clear-double-boot-test.js
+++ b/tests/integration/instance-initializers/clear-double-boot-test.js
@@ -18,4 +18,22 @@ module('Instance-initializer: clear-double-boot', function(hooks) {
     assert.notOk(this.element.querySelector('#fastboot-body-end'), 'There is no end marker');
     assert.notOk(this.element.querySelector('#content-in-between'), 'The content is between is gone');
   });
+
+  test('It can handle bad markup', async function(assert) {
+    this.set('BAD_HTML', `
+      <script type="x/boundary" id="fastboot-body-start"></script>
+      <div id="content-in-between">
+        <em><em>
+      </div>
+      <script type="x/boundary" id="fastboot-body-end"></script>
+    `);
+
+    // render the whole tree dynamically to more closely mimc bad markup cases
+    await render(hbs`{{{BAD_HTML}}}`);
+
+    clearHtml();
+    assert.notOk(this.element.querySelector('#fastboot-body-start'), 'There is no start marker');
+    assert.notOk(this.element.querySelector('#fastboot-body-end'), 'There is no end marker');
+    assert.notOk(this.element.querySelector('#content-in-between'), 'The content is between is gone');
+  })
 });


### PR DESCRIPTION
When rendering dynamic markup pulled from a database, we don't have a guarantee things will end up in the DOM where we want them to be.

Ember enforces good markup during the build, but there's no way to know if the following template will have valid markup:
```handlebars
// e.g. app/templates/article.hbs
<main id="content">
  {{{model.body}}}
</main>
```

The browser is a tolerant place, and it will do whatever it needs to do to create a valid DOM tree, even if that means swallowing up elements. A certain type of bad markup can wreak havoc on desired trees.

For example, let's say your fastboot returns the following HTML document to your browser:
```html
<!-- snip... -->
<body>
  <script type="x/boundary" id="fastboot-body-start"></script>
  <div>
    <p>
      Great article content here.
    </p>
    <em>With additional reporting<em> <---- ¯\_(ツ)_/¯
  </div>
  <script type="x/boundary" id="fastboot-body-end"></script>
</body>
```

When a browser parses that (at least when Chrome does), here's the DOM tree you wind up with:
```html
<body>
  <script type="x/boundary" id="fastboot-body-start"></script>
  <div>
    <p>
      Great article content here.
    </p>
    <em>
      With additional reporting
      <em></em>
    </em>
  </div>
  <em>
    <em>
      <script type="x/boundary" id="fastboot-body-end"></script>
    </em>
  </em>
</body>
```
Yikes.

When the `clear-double-boot` initializer runs, it assumes that the start and end markers have the same parent, which is sometimes not the case, as seen above.

Does this proposed solution work for you all? I know it might open a can of worms as far as working around DOM quirks, but this seems like a particularly nasty case that we can fix to ensure that the app finishes booting.