### PR TITLE
Checking if runningTests not defined or set to false

### DIFF
--- a/lib/utilities/fastboot-app-module.js
+++ b/lib/utilities/fastboot-app-module.js
@@ -12,7 +12,7 @@ module.exports = function fastbootAppModule(prefix, configAppAsString, isModuleU
   return [
     "",
     "if (typeof FastBoot === 'undefined') {",
-    "  if (typeof runningTests === 'undefined') {",
+    "  if (typeof runningTests === 'undefined' || !runningTests) {",
     "    require('{{MODULE_PREFIX}}/" + appSuffix + "')['default'].create({{CONFIG_APP}});",
     "  }",
     "}",


### PR DESCRIPTION
In embroider build `runningTests` is not defined whereas in ember-cli  build it is set to false. #706 