### PR TITLE
Embroider Support: Moved app factory module out of fastboot-app-module

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,8 +9,9 @@ const FastBootExpressMiddleware = require('fastboot-express-middleware');
 const FastBoot = require('fastboot');
 const chalk = require('chalk');
 
-const fastbootAppModule = require('./lib/utilities/fastboot-app-module');
+const fastbootAppBoot = require('./lib/utilities/fastboot-app-boot');
 const FastBootConfig = require('./lib/broccoli/fastboot-config');
+const fastbootAppFactoryModule = require('./lib/utilities/fastboot-app-factory-module');
 const migrateInitializers = require('./lib/build-utilities/migrate-initializers');
 const SilentError = require('silent-error');
 
@@ -107,8 +108,8 @@ module.exports = {
     }
 
     if (type === 'app-boot') {
-      const isModuleUnification = (typeof this.project.isModuleUnification === 'function') && this.project.isModuleUnification();
-      return fastbootAppModule(config.modulePrefix, JSON.stringify(config.APP || {}), isModuleUnification);
+      const isModuleUnification = this._isModuleUnification();
+      return fastbootAppBoot(config.modulePrefix, JSON.stringify(config.APP || {}), isModuleUnification);
     }
 
     // if the fastboot addon is installed, we overwrite the config-module so that the config can be read
@@ -174,10 +175,11 @@ module.exports = {
    */
   _getFastbootTree() {
     const appName = this._name;
+    const isModuleUnification = this._isModuleUnification();
 
     let fastbootTrees = [];
-    this._processAddons(this.project.addons, fastbootTrees);
 
+    this._processAddons(this.project.addons, fastbootTrees);
     // check the parent containing the fastboot directory
     const projectFastbootPath = path.join(this.project.root, 'fastboot');
     if (this.existsSync(projectFastbootPath)) {
@@ -189,6 +191,7 @@ module.exports = {
     let mergedFastBootTree = new MergeTrees(fastbootTrees, {
       overwrite: true
     });
+
     let funneledFastbootTrees = new Funnel(mergedFastBootTree, {
       destDir: appName
     });
@@ -196,12 +199,20 @@ module.exports = {
       registry: this._appRegistry
     });
 
+    // FastBoot app factory module
+    const writeFile = require('broccoli-file-creator');
+    let appFactoryModuleTree = writeFile("app-factory.js", fastbootAppFactoryModule(appName, this._isModuleUnification()));
+
+    let newProcessExtraTree = new MergeTrees([processExtraTree, appFactoryModuleTree], {
+      overwrite: true
+    });
+
     function stripLeadingSlash(filePath) {
       return filePath.replace(/^\//, '');
     }
 
     let appFilePath = stripLeadingSlash(this.app.options.outputPaths.app.js);
-    let finalFastbootTree = new Concat(processExtraTree, {
+    let finalFastbootTree = new Concat(newProcessExtraTree, {
       outputFile: appFilePath.replace(/\.js$/, '-fastboot.js')
     });
 
@@ -361,4 +372,8 @@ module.exports = {
 
     return checker.for('ember', 'bower');
   },
+  
+  _isModuleUnification() {
+    return (typeof this.project.isModuleUnification === 'function') && this.project.isModuleUnification();
+  }
 };

--- a/lib/utilities/fastboot-app-boot.js
+++ b/lib/utilities/fastboot-app-boot.js
@@ -1,0 +1,16 @@
+'use strict'
+
+// Added as app boot code to app.js that allows booting of the application
+// in browser. This code is injected during app-boot type of contentFor hook for ember-cli.
+module.exports = function fastbootAppBoot(prefix, configAppAsString, isModuleUnification) {
+  var appSuffix = isModuleUnification ? "src/main" : "app";
+  return [
+    "",
+    "if (typeof FastBoot === 'undefined') {",
+    "  if (!runningTests) {",
+    "    require('{{MODULE_PREFIX}}/" + appSuffix + "')['default'].create({{CONFIG_APP}});",
+    "  }",
+    "}",
+    ""
+  ].join("\n").replace(/\{\{MODULE_PREFIX\}\}/g, prefix).replace(/\{\{CONFIG_APP\}\}/g, configAppAsString);
+};

--- a/lib/utilities/fastboot-app-factory-module.js
+++ b/lib/utilities/fastboot-app-factory-module.js
@@ -7,16 +7,9 @@
 // The module defined here is prefixed with a `~` to make it less
 // likely to collide with user code, since it is not possible to
 // define a module with a name like this in the file system.
-module.exports = function fastbootAppModule(prefix, configAppAsString, isModuleUnification) {
+module.exports = function fastBootAppFactoryModule(prefix, isModuleUnification) {
   var appSuffix = isModuleUnification ? "src/main" : "app";
   return [
-    "",
-    "if (typeof FastBoot === 'undefined') {",
-    "  if (!runningTests) {",
-    "    require('{{MODULE_PREFIX}}/" + appSuffix + "')['default'].create({{CONFIG_APP}});",
-    "  }",
-    "}",
-    "",
     "define('~fastboot/app-factory', ['{{MODULE_PREFIX}}/" + appSuffix + "', '{{MODULE_PREFIX}}/config/environment'], function(App, config) {",
     "  App = App['default'];",
     "  config = config['default'];",
@@ -28,5 +21,5 @@ module.exports = function fastbootAppModule(prefix, configAppAsString, isModuleU
     "  };",
     "});",
     ""
-  ].join("\n").replace(/\{\{MODULE_PREFIX\}\}/g, prefix).replace(/\{\{CONFIG_APP\}\}/g, configAppAsString);
+  ].join("\n").replace(/\{\{MODULE_PREFIX\}\}/g, prefix);
 };

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "release-it": "^12.0.1",
     "release-it-lerna-changelog": "^1.0.2",
     "request": "^2.88.0",
-    "rsvp": "^4.8.3"
+    "rsvp": "^4.8.3",
+    "broccoli-file-creator": "^1.1.1"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"


### PR DESCRIPTION
* Cleaned up fastboot-app-module.
* Added Fastboot-app-factory-plugin to insert app factory module as part of <app>-fastboot.js
* This clean up ensures fastboot specific App-factory code is not shipped as part of browser assets.
* With Embroider not supporting `app-boot` type contentFor, this change ensures the insertion of the app-factory module is not dependent on `app-boot` step in the build process.

WIP: #700