### PR TITLE
Dev server forwards out of scope requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -306,12 +306,13 @@ module.exports = {
       app.use((req, resp, next) => {
         const fastbootQueryParam = (req.query.hasOwnProperty('fastboot') && req.query.fastboot === 'false') ? false : true;
         const enableFastBootServe = !process.env.FASTBOOT_DISABLED && fastbootQueryParam;
-        const broccoliHeader = req.headers['x-broccoli'];
-        const outputPath = broccoliHeader['outputPath'];
 
         if (req.serveUrl && enableFastBootServe) {
           // if it is a base page request, then have fastboot serve the base page
           if (!this.fastboot) {
+            const broccoliHeader = req.headers['x-broccoli'];
+            const outputPath = broccoliHeader['outputPath'];
+
             // TODO(future): make this configurable for allowing apps to pass sandboxGlobals
             // and custom sandbox class
             this.ui.writeLine(chalk.green('App is being served by FastBoot'));

--- a/test/root-url-test.js
+++ b/test/root-url-test.js
@@ -40,6 +40,18 @@ describe('rootUrl acceptance', function() {
       });
   });
 
+  it('Out of scope requests', function() {
+    return request({
+      url: 'http://localhost:49741/foo-bar/',
+      headers: {
+        'Accept': 'text/html'
+      }
+    })
+      .then(function(response) {
+        expect(response.statusCode).to.equal(404);
+      });
+  });
+
   it('with fastboot query parameter turned on', function() {
     return request({
       url: 'http://localhost:49741/my-root/?fastboot=true',


### PR DESCRIPTION
When running a dev server and an app is mounted at a root URL other than `/`, it is possible for requests to make it to the fastboot server that do not have the `x-broccoli` header.  Moving parsing of this header deeper into the request allows for these out of scope requests to be forwarded on.

Resolves #716 