### PR TITLE
cheerio is used outside of tests so must be a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "broccoli-merge-trees": "^3.0.1",
     "broccoli-plugin": "^1.3.1",
     "chalk": "^2.4.1",
+    "cheerio": "^1.0.0-rc.3",
     "ember-cli-babel": "^7.1.0",
     "ember-cli-lodash-subset": "2.0.1",
     "ember-cli-preprocess-registry": "^3.1.2",
@@ -41,11 +42,11 @@
   "devDependencies": {
     "body-parser": "^1.18.3",
     "broccoli-asset-rev": "^3.0.0",
+    "broccoli-file-creator": "^1.1.1",
     "broccoli-test-helper": "^1.5.0",
     "chai": "^4.1.2",
     "chai-fs": "^2.0.0",
     "chai-string": "^1.4.0",
-    "cheerio": "^1.0.0-rc.3",
     "co": "^4.6.0",
     "ember-ajax": "^3.1.0",
     "ember-cli": "~3.3.0",
@@ -75,8 +76,7 @@
     "release-it": "^12.0.1",
     "release-it-lerna-changelog": "^1.0.2",
     "request": "^2.88.0",
-    "rsvp": "^4.8.3",
-    "broccoli-file-creator": "^1.1.1"
+    "rsvp": "^4.8.3"
   },
   "engines": {
     "node": "6.* || 8.* || >= 10.*"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "broccoli-concat": "^3.7.1",
+    "broccoli-file-creator": "^2.1.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^3.0.1",
     "broccoli-plugin": "^1.3.1",
@@ -42,7 +43,6 @@
   "devDependencies": {
     "body-parser": "^1.18.3",
     "broccoli-asset-rev": "^3.0.0",
-    "broccoli-file-creator": "^1.1.1",
     "broccoli-test-helper": "^1.5.0",
     "chai": "^4.1.2",
     "chai-fs": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1858,6 +1858,14 @@ broccoli-file-creator@^1.1.1:
     broccoli-plugin "^1.1.0"
     mkdirp "^0.5.1"
 
+broccoli-file-creator@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/broccoli-file-creator/-/broccoli-file-creator-2.1.1.tgz#7351dd2496c762cfce7736ce9b49e3fce0c7b7db"
+  integrity sha512-YpjOExWr92C5vhnK0kmD81kM7U09kdIRZk9w4ZDCDHuHXW+VE/x6AGEOQQW3loBQQ6Jk+k+TSm8dESy4uZsnjw==
+  dependencies:
+    broccoli-plugin "^1.1.0"
+    mkdirp "^0.5.1"
+
 broccoli-filter@^1.2.2, broccoli-filter@^1.2.3:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/broccoli-filter/-/broccoli-filter-1.3.0.tgz#71e3a8e32a17f309e12261919c5b1006d6766de6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2394,6 +2394,7 @@ check-error@^1.0.1:
 cheerio@^1.0.0-rc.3:
   version "1.0.0-rc.3"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.3.tgz#094636d425b2e9c0f4eb91a46c05630c9a1a8bf6"
+  integrity sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==
   dependencies:
     css-select "~1.2.0"
     dom-serializer "~0.1.1"


### PR DESCRIPTION
devDependency

fixes: https://github.com/ember-fastboot/ember-cli-fastboot/pull/701#discussion_r323442529
[fixes #724]