### PR TITLE
Prevent errors when `fastboot-body-end` is not present.

### DIFF
--- a/addon/instance-initializers/clear-double-boot.js
+++ b/addon/instance-initializers/clear-double-boot.js
@@ -8,8 +8,9 @@
 // application will replace the pre-rendered output
 export function clearHtml() {
   let current = document.getElementById('fastboot-body-start');
-  if (current) {
-    let endMarker = document.getElementById('fastboot-body-end');
+  let endMarker = document.getElementById('fastboot-body-end');
+
+  if (current && endMarker) {
     let shoeboxNodes = document.querySelectorAll('[type="fastboot/shoebox"]');
     let shoeboxNodesArray = []; // Note that IE11 doesn't support more concise options like Array.from, so we have to do something like this
     for(let i=0; i < shoeboxNodes.length; i++){

--- a/tests/integration/instance-initializers/clear-double-boot-test.js
+++ b/tests/integration/instance-initializers/clear-double-boot-test.js
@@ -36,4 +36,15 @@ module('Instance-initializer: clear-double-boot', function(hooks) {
     assert.notOk(this.element.querySelector('#fastboot-body-end'), 'There is no end marker');
     assert.notOk(this.element.querySelector('#content-in-between'), 'The content is between is gone');
   })
+
+  test('It can handle missing fastboot-body-end', async function(assert) {
+    this.set('BAD_HTML', `<script type="x/boundary" id="fastboot-body-start"></script>`);
+
+    // render the whole tree dynamically to more closely mimc bad markup cases
+    await render(hbs`{{{BAD_HTML}}}`);
+
+    clearHtml();
+
+    assert.strictEqual(this.element.innerHTML, this.get('BAD_HTML'));
+  })
 });

--- a/vendor/experimental-render-mode-rehydrate.js
+++ b/vendor/experimental-render-mode-rehydrate.js
@@ -23,7 +23,10 @@
       // guarded for
       current.parentNode.removeChild(current);
       var end = document.getElementById('fastboot-body-end');
-      end.parentNode.removeChild(end);
+
+      if (end) {
+        end.parentNode.removeChild(end);
+      }
     }
   }
 })();


### PR DESCRIPTION
The current implementation of `clear-double-render` guards for when `fastboot-body-start` is not present, but does not check if `fastboot-body-end` is present before attempting to remove it (therefore causing an `Cannot call 'parentElement' of null` error).

Note: There are still some issues with this approach (e.g. why is `fastboot-body-start` present but `fastboot-body-end` is missing), and this change does not directly address all of the issues. It **does** prevent a masking error from happening.