### PR TITLE
Add 'node: current' to the targets file on install

### DIFF
--- a/packages/ember-cli-fastboot/blueprints/ember-cli-fastboot/index.js
+++ b/packages/ember-cli-fastboot/blueprints/ember-cli-fastboot/index.js
@@ -1,0 +1,44 @@
+/* eslint-env node */
+const recast = require('recast');
+const { readFileSync, writeFileSync } = require('fs');
+
+module.exports = {
+  description: '',
+  normalizeEntityName() {
+    // no-op
+  },
+
+  afterInstall() {
+    let targetsFile = './config/targets.js'
+
+    if(this.project.isEmberCLIAddon()) {
+      targetsFile = './tests/dummy/config/targets.js';
+    }
+
+    const targetsAst = recast.parse(readFileSync(targetsFile));
+
+    recast.visit(targetsAst, {
+      visitAssignmentExpression (path) {
+        let node = path.node;
+
+        if (node.left.object.name === 'module' && node.left.property.name === 'exports') {
+          let nodeProperty = node.right.properties.find(property => property.key.name === 'node');
+
+          if(!nodeProperty) {
+            let builders = recast.types.builders;
+            nodeProperty = builders.property(
+              'init',
+              builders.identifier('node'),
+              builders.literal('current')
+            );
+            node.right.properties.push(nodeProperty);
+          }
+        }
+
+        this.traverse(path);
+      }
+    });
+
+    writeFileSync(targetsFile, recast.print(targetsAst, { tabWidth: 2, quote: 'single' }).code);
+  }
+};

--- a/packages/ember-cli-fastboot/package.json
+++ b/packages/ember-cli-fastboot/package.json
@@ -39,6 +39,7 @@
     "fs-extra": "^7.0.0",
     "json-stable-stringify": "^1.0.1",
     "md5-hex": "^2.0.0",
+    "recast": "^0.19.1",
     "silent-error": "^1.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11772,7 +11772,7 @@ parse5@5.1.0:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.0.tgz#c59341c9723f414c452975564c7c00a68d58acd2"
   integrity sha512-fxNG2sQjHvlVAYmzBZS9YlDp6PTSSDwa98vkD4QgVDDCAo84z5X1t5XyJQ62ImdLXx5NdIIfihey6xpum9/gRQ==
 
-parse5@5.1.1:
+parse5@5.1.1, parse5@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
@@ -11783,11 +11783,6 @@ parse5@^3.0.3:
   integrity sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==
   dependencies:
     "@types/node" "*"
-
-parse5@^5.1.1:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
-  integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
 
 parseqs@0.0.5:
   version "0.0.5"
@@ -12461,6 +12456,16 @@ recast@^0.18.1:
   version "0.18.10"
   resolved "https://registry.yarnpkg.com/recast/-/recast-0.18.10.tgz#605ebbe621511eb89b6356a7e224bff66ed91478"
   integrity sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==
+  dependencies:
+    ast-types "0.13.3"
+    esprima "~4.0.0"
+    private "^0.1.8"
+    source-map "~0.6.1"
+
+recast@^0.19.1:
+  version "0.19.1"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.19.1.tgz#555f3612a5a10c9f44b9a923875c51ff775de6c8"
+  integrity sha512-8FCjrBxjeEU2O6I+2hyHyBFH1siJbMBLwIRvVr1T3FD2cL754sOaJDsJ/8h3xYltasbJ8jqWRIhMuDGBSiSbjw==
   dependencies:
     ast-types "0.13.3"
     esprima "~4.0.0"


### PR DESCRIPTION
This is something that we discussed at the last fastboot weekly meeting, essentially it is designed to fix the issue where people have errors with nullish coalescing during a fastboot build because their targets file only includes browsers that natively support the feature and it is not getting transpiled. 

This PR adds the `node: "current"` to the targets file, which will always refer to the current node version that is **running** the build. You can read more here: https://babeljs.io/docs/en/babel-preset-env#targetsnode

I thought I would submit the working implementation before we discussed how to test this 🤔  maybe a topic for this week's meeting.

There are some issues with this implementation, even though I know it works (and [I've been using something similar for quite some time](https://github.com/empress/empress-blog/pull/68/files)). The first issue that might be a blocker but I don't know, is that it doesn't prompt you like normal blueprint changes to see what the diff is and ask if you want to apply it 🤔  because it's writing outside of the context of ember-cli it just writes the changes to the file directly. I don't actually know how to fix this