### PR TITLE
Remove the second version of broccoli-file-creator from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "devDependencies": {
     "body-parser": "^1.18.3",
     "broccoli-asset-rev": "^3.0.0",
-    "broccoli-file-creator": "^1.1.1",
     "broccoli-test-helper": "^1.5.0",
     "chai": "^4.1.2",
     "chai-fs": "^2.0.0",


### PR DESCRIPTION
We had two version of broccoli-file-creator in the package.json this removes the older version. 