### PR TITLE
Move `.gitignore` into root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,12 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist/
-/tmp/
+dist/
+tmp/
 
 # dependencies
-/bower_components/
-/node_modules/
+bower_components/
+node_modules/
 
 # misc
 /.sass-cache


### PR DESCRIPTION
Prior to this, the root `node_modules` folder is considered an untracked
file after a fresh checkout + `yarn`.