### PR TITLE
Throw a helpful error when people use `isFastboot` instead of `isFastBoot`

### DIFF
--- a/packages/ember-cli-fastboot/addon/services/fastboot.js
+++ b/packages/ember-cli-fastboot/addon/services/fastboot.js
@@ -69,6 +69,13 @@ const FastBootService = Service.extend({
   headers: deprecatingAlias('request.headers', { id: 'fastboot.headers-to-request', until: '0.9.9' }),
   isFastBoot: typeof FastBoot !== 'undefined',
 
+  isFastboot: computed(function() {
+    assert(
+      'The fastboot service does not have an `isFastboot` property. This is likely a typo. Please use `isFastBoot` instead.',
+      false
+    );
+  }),
+
   init() {
     this._super(...arguments);
 

--- a/packages/ember-cli-fastboot/tests/unit/services/fastboot-test.js
+++ b/packages/ember-cli-fastboot/tests/unit/services/fastboot-test.js
@@ -10,6 +10,12 @@ module('Unit | Service | fastboot in the browser', function(hooks) {
     assert.equal(service.get('isFastBoot'), false, `it should be false`);
   });
 
+  test('isFastboot', function(assert) {
+    let service = this.owner.lookup('service:fastboot');
+    assert.throws(() => service.isFastboot, `it should throw`);
+    assert.throws(() => service.get('isFastboot'), `it should throw`);
+  });
+
   test('request', function(assert) {
     let service = this.owner.lookup('service:fastboot');
     assert.equal(service.get('request'), null, `it should be null`);


### PR DESCRIPTION
https://discord.com/channels/480462759797063690/485861149821239298/821177803721801778