### PR TITLE
Schema version 6: lookup fastboot info

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Yarn Install
         run: yarn install --ignore-engines --frozen-lockfile
       - name: Integration Tests
-        run: yarn workspace integration-tests test 
+        run: yarn workspace integration-tests test
 
   test-packages:
     name: Test Packages

--- a/package.json
+++ b/package.json
@@ -9,7 +9,16 @@
     "packages/*",
     "test-packages/*"
   ],
+  "scripts": {
+    "test": "npm-run-all test:*",
+    "test:ember-cli-fastboot": "yarn workspace ember-cli-fastboot test:ember",
+    "test:fastboot": "yarn workspace fastboot test",
+    "test:fastboot-express-middleware": "yarn workspace fastboot-express-middleware test",
+    "test:fastboot-app-server": "yarn workspace fastboot-app-server test:mocha",
+    "test:integration": "yarn workspace integration-tests test"
+  },
   "devDependencies": {
+    "npm-run-all": "^4.1.5",
     "release-it": "^14.2.2",
     "release-it-lerna-changelog": "^3.1.0",
     "release-it-yarn-workspaces": "^2.0.0"

--- a/packages/ember-cli-fastboot/addon/services/fastboot.js
+++ b/packages/ember-cli-fastboot/addon/services/fastboot.js
@@ -78,6 +78,7 @@ const FastBootService = Service.extend({
 
     let shoebox = Shoebox.create({ fastboot: this });
     this.set('shoebox', shoebox);
+    this.set('_fastbootInfo', getOwner(this).lookup('info:-fastboot'));
   },
 
   response: readOnly('_fastbootInfo.response'),

--- a/packages/ember-cli-fastboot/lib/broccoli/fastboot-config.js
+++ b/packages/ember-cli-fastboot/lib/broccoli/fastboot-config.js
@@ -11,7 +11,7 @@ const Plugin = require('broccoli-plugin');
 
 const stringify = require('json-stable-stringify');
 
-const LATEST_SCHEMA_VERSION = 3;
+const LATEST_SCHEMA_VERSION = 6;
 
 module.exports = class FastBootConfig extends Plugin {
   constructor(inputNode, options) {

--- a/packages/ember-cli-fastboot/tests/unit/services/fastboot/shoebox-test.js
+++ b/packages/ember-cli-fastboot/tests/unit/services/fastboot/shoebox-test.js
@@ -58,33 +58,27 @@ module('Unit | Service | fastboot | shoebox', function(hooks) {
   });
 
   test('retrieve returns undefined if isFastBoot true and shoebox is missing', function(assert) {
+    this.owner.register('info:-fastboot', {}, { instantiate: false });
     let service = this.owner.factoryFor('service:fastboot').create({
-      isFastBoot: true,
-      _fastbootInfo: {}
+      isFastBoot: true
     });
 
     assert.strictEqual(service.get('shoebox').retrieve('foo'), undefined);
   });
 
   test('retrieve returns undefined if isFastBoot true and key is missing', function(assert) {
+    this.owner.register('info:-fastboot', { shoebox: {} }, { instantiate: false });
     let service = this.owner.factoryFor('service:fastboot').create({
-      isFastBoot: true,
-      _fastbootInfo: {
-        shoebox: {}
-      }
+      isFastBoot: true
     });
 
     assert.strictEqual(service.get('shoebox').retrieve('foo'), undefined);
   });
 
   test('retrieve returns value if isFastBoot true and key is present', function(assert) {
+    this.owner.register('info:-fastboot', { shoebox: { foo: 'bar' } }, { instantiate: false });
     let service = this.owner.factoryFor('service:fastboot').create({
-      isFastBoot: true,
-      _fastbootInfo: {
-        shoebox: {
-          foo: 'bar'
-        }
-      }
+      isFastBoot: true
     });
 
     assert.strictEqual(service.get('shoebox').retrieve('foo'), 'bar');

--- a/packages/fastboot/src/fastboot-info.js
+++ b/packages/fastboot/src/fastboot-info.js
@@ -30,14 +30,4 @@ module.exports = class FastBootInfo {
   deferRendering(promise) {
     this.deferredPromise = Promise.all([this.deferredPromise, promise]);
   }
-
-  /*
-   * Registers this FastBootInfo instance in the registry of an Ember
-   * ApplicationInstance. It is configured to be injected into the FastBoot
-   * service, ensuring it is available inside instance initializers.
-   */
-  register(instance) {
-    instance.register('info:-fastboot', this, { instantiate: false });
-    instance.inject('service:fastboot', '_fastbootInfo', 'info:-fastboot');
-  }
 };


### PR DESCRIPTION
Implicit injection is deprecated https://deprecations.emberjs.com/v3.x#toc_implicit-injections

Fixes https://github.com/ember-fastboot/ember-cli-fastboot/issues/819
Depends on https://github.com/ember-fastboot/ember-cli-fastboot/pull/822

This is breaking change because user needs to upgrade to compatible `fastboot`