### PR TITLE
Restore the legacy tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,5 @@ jobs:
       - name: Run Mocha Tests
         working-directory: ./packages/ember-cli-fastboot
         run: |
-          volta install npm@4
           npm --version
           yarn test:mocha

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Yarn Install
         run: yarn install --ignore-engines --frozen-lockfile
       - name: Integration Tests
-        run: yarn workspace integration-tests test 
+        run: yarn workspace integration-tests test
 
   test-packages:
     name: Test Packages
@@ -90,3 +90,35 @@ jobs:
         run: yarn workspace basic-app test:mocha
       - name: Custom App
         run: yarn workspace custom-fastboot-app test:mocha
+
+  test-legacy-mocha:
+    name: Legacy Mocha Tests - ${{ matrix.node-version }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['14', '12', '10']
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: volta-cli/action@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      # Remove test-packages folder so that we don't leak node_modules between apps
+      - name: Remove test-packages
+        run: |
+          rm -rf test-packages
+      - name: Yarn Install
+        working-directory: ./packages/ember-cli-fastboot
+        run: |
+          yarn install --ignore-engines --frozen-lockfile
+      - name: Run Mocha Tests
+        working-directory: ./packages/ember-cli-fastboot
+        run: |
+          volta install npm@4
+          npm --version
+          yarn test:mocha

--- a/packages/ember-cli-fastboot/package.json
+++ b/packages/ember-cli-fastboot/package.json
@@ -46,6 +46,7 @@
     "body-parser": "^1.18.3",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-test-helper": "^1.5.0",
+    "co": "4.6.0",
     "chai": "^4.1.2",
     "chai-fs": "^2.0.0",
     "chai-string": "^1.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,6 +5577,11 @@ clone@^2.0.0, clone@^2.1.2:
   resolved "https://registry.yarnpkg.com/clone/-/clone-2.1.2.tgz#1b7f4b9f591f1e8f83670401600345a02887435f"
   integrity sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=
 
+co@4.6.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
+  integrity sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"


### PR DESCRIPTION
The tests were removed in this PR https://github.com/ember-fastboot/ember-cli-fastboot/pull/805

These [tests](https://github.com/ember-fastboot/ember-cli-fastboot/tree/master/packages/ember-cli-fastboot/test) have not been exercised this the above PR.
https://github.com/ember-fastboot/ember-cli-fastboot/tree/master/packages/ember-cli-fastboot/test

Adding the npm package `[co](https://www.npmjs.com/package/co)` which is used when running the legacy tests