### PR TITLE
Fix use of Ember global, breaking Ember 4

### DIFF
--- a/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
+++ b/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
@@ -1,7 +1,7 @@
 (function() {
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
-    var Ember = require('ember').default;
+    var Ember = require.has('ember') ? require('ember').default : Ember;
 
     if (
       current &&

--- a/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
+++ b/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
@@ -1,6 +1,7 @@
 (function() {
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
+    var Ember = require('ember').default;
 
     if (
       current &&


### PR DESCRIPTION
I think it's not ideal to rely on assumptions about the global `require()` and AMD-style modules, especially in a brave new Embroider world. But after all this is what the [RFC706 suggests in the drawbacks section](https://emberjs.github.io/rfcs/0706-deprecate-ember-global.html#drawbacks), and should be good enough to fix this for the short term...

Fixes #827