### PR TITLE
Support extracting fastboot specific config from meta tag

### DIFF
--- a/packages/fastboot/src/html-entrypoint.js
+++ b/packages/fastboot/src/html-entrypoint.js
@@ -27,6 +27,8 @@ function htmlEntrypoint(appName, distPath, htmlPath) {
       let relativeSrc = urlWithin(src, rootURL);
       if (relativeSrc) {
         scripts.push(path.join(distPath, relativeSrc));
+      } else if (element.tagName === 'FASTBOOT-SCRIPT') {
+        scripts.push(path.join(distPath, src));
       }
     }
     if (element.tagName === 'FASTBOOT-SCRIPT') {

--- a/packages/fastboot/test/html-entrypoint-test.js
+++ b/packages/fastboot/test/html-entrypoint-test.js
@@ -250,6 +250,7 @@ describe('htmlEntrypoint', function() {
         <html>
           <meta name="my-app/config/environment" content="%7B%22rootURL%22%3A%22%2Fcustom-root-url%2F%22%7D" >
           <body>
+            <fastboot-script src="foo.js"></fastboot-script>
             <script src="/custom-root-url/bar.js"></script>
           </body>
         </html>
@@ -259,6 +260,6 @@ describe('htmlEntrypoint', function() {
     fixturify.writeSync(tmpLocation, project);
 
     let { scripts } = htmlEntrypoint('my-app', tmpLocation, 'index.html');
-    expect(scripts).to.deep.equal([`${tmpLocation}/bar.js`]);
+    expect(scripts).to.deep.equal([`${tmpLocation}/foo.js`, `${tmpLocation}/bar.js`]);
   });
 });


### PR DESCRIPTION
Adding support to extract fastboot config from config/fastboot-environement meta tag and fallback to config/environement.

Extracted from https://github.com/ember-fastboot/ember-cli-fastboot/pull/822, need to rebase onto https://github.com/ember-fastboot/ember-cli-fastboot/pull/853
