### PR TITLE
Avoid implicit injection _fastbootInfo deprecation pt 2

### DIFF
--- a/packages/ember-cli-fastboot/addon/services/fastboot.js
+++ b/packages/ember-cli-fastboot/addon/services/fastboot.js
@@ -89,9 +89,19 @@ const FastBootService = Service.extend({
     return RequestObject.create({ request: get(this, '_fastbootInfo.request') });
   }),
 
-  _fastbootInfo: computed(function() {
-    // this getter is to avoid deprecation from [RFC - 680](https://github.com/emberjs/rfcs/pull/680)
-    return getOwner(this).lookup('info:-fastboot');
+  _fastbootInfo: computed({
+    get() {
+      if (this.__fastbootInfo) {
+        return this.__fastbootInfo;
+      }
+
+      // this getter is to avoid deprecation from [RFC - 680](https://github.com/emberjs/rfcs/pull/680)
+      return getOwner(this).lookup('info:-fastboot');
+    },
+    set(_key, value) {
+      this.__fastbootInfo = value;
+      return value;
+    }
   }),
 
   deferRendering(promise) {

--- a/packages/ember-cli-fastboot/addon/services/fastboot.js
+++ b/packages/ember-cli-fastboot/addon/services/fastboot.js
@@ -89,13 +89,13 @@ const FastBootService = Service.extend({
     return RequestObject.create({ request: get(this, '_fastbootInfo.request') });
   }),
 
+  // this getter/setter pair is to avoid deprecation from [RFC - 680](https://github.com/emberjs/rfcs/pull/680)
   _fastbootInfo: computed({
     get() {
       if (this.__fastbootInfo) {
         return this.__fastbootInfo;
       }
 
-      // this getter is to avoid deprecation from [RFC - 680](https://github.com/emberjs/rfcs/pull/680)
       return getOwner(this).lookup('info:-fastboot');
     },
     set(_key, value) {


### PR DESCRIPTION
This actually fixes #841.

Note: this way this works is if there is a setter (not just a getter), then it overrides and doesn't issue the deprecation.

https://github.com/emberjs/ember.js/pull/19358/files#diff-2600f49bdcd760f57af70712f38930aca2c85c30752165032d9998359ed9109dR265-R295