### PR TITLE
Ensure rehydration works on Ember < 3.27

### DIFF
--- a/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
+++ b/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
@@ -1,14 +1,14 @@
 (function() {
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
-    var Ember = require.has('ember') ? require('ember').default : Ember;
+    var _Ember = require.has('ember') ? require('ember').default : Ember;
 
     if (
       current &&
-      typeof Ember.ViewUtils.isSerializationFirstNode === 'function' &&
-      Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)
+      typeof _Ember.ViewUtils.isSerializationFirstNode === 'function' &&
+      _Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)
     ) {
-      Ember.ApplicationInstance.reopen({
+      _Ember.ApplicationInstance.reopen({
         _bootSync: function(options) {
           if (options === undefined) {
             options = {


### PR DESCRIPTION
The fallback for the guard introduced in 32d6f074c66aed32898a05934dad24b4b8cb19e4 (which takes effect when running on Ember < 3.27) is somewhat fundamentally borked. Due to the usage of `var Ember` and the fact that `var` hoists, the fallback in the ternary **can never** anything but `undefined`.

