### PR TITLE
Cache dependencies in GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,9 +32,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Yarn Install
         run: yarn install --ignore-engines --frozen-lockfile
       - name: Run ember-cli-fastboot Tests
@@ -60,9 +61,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Yarn Install
         run: yarn install --ignore-engines --frozen-lockfile
       - name: Integration Tests
@@ -81,9 +83,10 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
+          cache: yarn
       - name: Yarn Install
         run: yarn install --ignore-engines --frozen-lockfile
       - name: Basic App
@@ -144,6 +147,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 14
+          cache: yarn
       - run: yarn install --ignore-engines --frozen-lockfile
       - name: test
         run: yarn workspace ember-cli-fastboot ember try:one ${{ matrix.ember-try-scenario }} --skip-cleanup


### PR DESCRIPTION
PR to speed up CI times on GitHub Actions by caching dependencies.

References:
* https://github.com/actions/setup-node#caching-packages-dependencies
* https://github.com/ember-cli/ember-cli/blob/master/blueprints/addon/files/.github/workflows/ci.yml

the change is to use `actions/setup-node@v2` with `cache: yarn` option