### PR TITLE
Update .npmignore to ignore .github and test folders

### DIFF
--- a/packages/ember-cli-fastboot/.npmignore
+++ b/packages/ember-cli-fastboot/.npmignore
@@ -25,6 +25,7 @@
 /CONTRIBUTING.md
 /ember-cli-build.js
 /testem.js
+/test/
 /tests/
 /yarn.lock
 .gitkeep

--- a/packages/fastboot-app-server/.npmignore
+++ b/packages/fastboot-app-server/.npmignore
@@ -2,5 +2,7 @@
 .eslintcache
 .eslintignore
 .eslintrc.js
+.mocharc.js
 .travis.yml
 test/
+/.github/

--- a/packages/fastboot-express-middleware/.npmignore
+++ b/packages/fastboot-express-middleware/.npmignore
@@ -1,6 +1,8 @@
-test
 .gitignore
 .eslintcache
 .eslintignore
 .eslintrc.js
+.mocharc.js
 .travis.yml
+test/
+/.github/


### PR DESCRIPTION
This shrinks the "unpacked size" for a few Kb