### PR TITLE
Allow disabling default logging in fastboot-app-server

### DIFF
--- a/packages/fastboot-app-server/README.md
+++ b/packages/fastboot-app-server/README.md
@@ -42,6 +42,7 @@ let server = new FastBootAppServer({
   host: '0.0.0.0', // Optional - Sets the host the server listens on.
   port: 4000, // Optional - Sets the port the server listens on (defaults to the PORT env var or 3000).
   buildSandboxGlobals(defaultGlobals) { // Optional - Make values available to the Ember app running in the FastBoot server, e.g. "MY_GLOBAL" will be available as "GLOBAL_VALUE"
+  log: true, // Optional - Specifies whether the server should use its default request logging. Useful for turning off default logging when providing custom logging middlewares
     return Object.assign({}, defaultGlobals, { GLOBAL_VALUE: MY_GLOBAL });
   },
   chunkedResponse: true // Optional - Opt-in to chunked transfer encoding, transferring the head, body and potential shoeboxes in separate chunks. Chunked transfer encoding should have a positive effect in particular when the app transfers a lot of data in the shoebox.
@@ -132,6 +133,26 @@ const server = FastBootAppServer({
   beforeMiddleware: function (app) { app.use(modifyRequest); },
   afterMiddleware: function (app) { app.use(handleErrors); }
 })
+```
+
+## Logging
+
+We provide simple log output by default, but if you want more logging control, you can disable the
+simple logger using the `log: false` option, and provide a custom middleware that suits your logging needs:
+
+```js
+let server = new FastBootAppServer({
+  log: false,
+  beforeMiddleware: function(app) {
+    let logger = function(req, res, next) {
+      console.log('Hello from custom request logger');
+
+      next();
+    };
+
+    app.use(logger);
+  },
+});
 ```
 
 ## Downloaders

--- a/packages/fastboot-app-server/src/fastboot-app-server.js
+++ b/packages/fastboot-app-server/src/fastboot-app-server.js
@@ -25,6 +25,7 @@ class FastBootAppServer {
     this.afterMiddleware = options.afterMiddleware;
     this.buildSandboxGlobals = options.buildSandboxGlobals;
     this.chunkedResponse = options.chunkedResponse;
+    this.log = options.log;
 
     if (!this.ui) {
       let UI = require('./ui');

--- a/packages/fastboot-app-server/src/worker.js
+++ b/packages/fastboot-app-server/src/worker.js
@@ -19,6 +19,7 @@ class Worker {
     this.afterMiddleware = options.afterMiddleware;
     this.buildSandboxGlobals = options.buildSandboxGlobals;
     this.chunkedResponse = options.chunkedResponse;
+    this.log = options.log;
 
     if (!this.httpServer) {
       this.httpServer = new ExpressHTTPServer({
@@ -80,6 +81,7 @@ class Worker {
     return fastbootMiddleware({
       fastboot: this.fastboot,
       chunkedResponse: this.chunkedResponse,
+      log: this.log,
     });
   }
 


### PR DESCRIPTION
This PR adds a `log` boolean option to the `FastBootAppServer` constructor so that we can disable the default logger when using a custom logging function in `fastboot-server.js`.

By default, `fastboot-app-server` will output request logs like this:

```
2022-03-09T15:40:47-06:00: 2022-03-09T21:40:47.716Z 200 OK /
2022-03-09T15:43:16-06:00: 2022-03-09T21:43:16.147Z 200 OK /users/123
```

We need more control over logs (to provide extra info in deployed environments) so we decided to add our own logging middleware, but now the default logger is making noise and would prefer to disable it.

In the [fastboot-express-middleware](https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/packages/fastboot-express-middleware) there's already a [line](https://github.com/ember-fastboot/ember-cli-fastboot/blob/master/packages/fastboot-express-middleware/src/index.js#L16) that prevents logging in case a false `log` option is provided. This PR passes this option to the `fastboot-express-middleware`. 



