### PR TITLE
chore/remove-outdated-readme-warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,9 +624,7 @@ The above configuration will be available in Node via the `FastBoot.config()` fu
 
 ## Known Limitations
 
-While FastBoot is under active development, there are several major
-restrictions you should be aware of. Only the most brave should even
-consider deploying this to production.
+There are a few key restrictions developers should be aware of with FastBoot.
 
 ### No `didInsertElement`
 

--- a/README.md
+++ b/README.md
@@ -7,12 +7,10 @@ FastBoot allows you to render and serve Ember.js apps on the server.
 Using FastBoot, you can serve rendered HTML to browsers and
 other clients without requiring them to download JavaScript assets.
 
-Currently, the set of Ember applications supported is extremely limited.
-As we fix more issues, we expect that set to grow rapidly. See [Known
-Limitations](#known-limitations) below for a full-list.
-
-The bottom line is that you should not (yet) expect to install this add-on in
-your production app and have FastBoot work.
+While FastBoot is has decent support in the Ember ecosystem these days, some
+application code, add-ons or other dependencies may need to be modified to work
+when being rendered serverside (e.g. you cannot call the `window` object during
+FastBoot).
 
 ## Installation
 


### PR DESCRIPTION
This PR removes a couple of outdated warnings about using FastBoot in the README. Pretty much superseding https://github.com/ember-fastboot/ember-cli-fastboot/pull/868.