### PR TITLE
Pass the log argument to worker in fastboot-app-server

### DIFF
--- a/packages/fastboot-app-server/src/fastboot-app-server.js
+++ b/packages/fastboot-app-server/src/fastboot-app-server.js
@@ -49,6 +49,7 @@ class FastBootAppServer {
         afterMiddleware: this.afterMiddleware,
         buildSandboxGlobals: this.buildSandboxGlobals,
         chunkedResponse: this.chunkedResponse,
+        log: this.log,
       });
 
       this.worker.start();


### PR DESCRIPTION
This is necessary for fastboot middleware to receive logging options specified in fastboot-app-server