### PR TITLE
fix: removes slow leak by emptying cache for source maps

### DIFF
--- a/packages/fastboot/src/scripts/install-source-map-support.js
+++ b/packages/fastboot/src/scripts/install-source-map-support.js
@@ -1,12 +1,10 @@
 'use strict';
 /* globals sourceMapSupport */
 
-Error.prepareStackTrace = function prepareStackTrace(error, stack) {
-  return error + stack.map(frame => '\n    at ' + sourceMapSupport.wrapCallSite(frame)).join('');
-};
 Error.stackTraceLimit = Infinity;
 
 sourceMapSupport.install({
   environment: 'node',
+  emptyCacheBetweenOperations: true,
   handleUncaughtExceptions: false,
 });


### PR DESCRIPTION
A faster fix for the slow memory leak explained in https://github.com/ember-fastboot/ember-cli-fastboot/pull/894, but without depending on the vm to have source maps knowledge which is currently a bug.