### PR TITLE
feat: adds a environment variable to opt out of source maps

### DIFF
--- a/packages/fastboot/README.md
+++ b/packages/fastboot/README.md
@@ -60,6 +60,8 @@ FastBoot.distPath // readOnly accessor that provides the dist path for the curre
 
 ### Additional configuration
 
+> By default source maps are enabled by the source-maps-support package. Setting an environment variable `FASTBOOT_SOURCEMAPS_DISABLE=true` will bypass this package effectively disabling source maps support.
+
 `app.visit` takes a second parameter as `options` above which a map and allows to define additional optional per request
 configuration:
 

--- a/packages/fastboot/src/ember-app.js
+++ b/packages/fastboot/src/ember-app.js
@@ -54,10 +54,14 @@ class EmberApp {
       this.config = allConfig;
     }
 
-    this.scripts = buildScripts([
-      require.resolve('./scripts/install-source-map-support'),
-      ...config.scripts,
-    ]);
+    if (process.env.FASTBOOT_SOURCEMAPS_DISABLE) {
+      this.scripts = buildScripts([...config.scripts]);
+    } else {
+      this.scripts = buildScripts([
+        require.resolve('./scripts/install-source-map-support'),
+        ...config.scripts,
+      ]);
+    }
 
     // default to 1 if maxSandboxQueueSize is not defined so the sandbox is pre-warmed when process comes up
     const maxSandboxQueueSize = options.maxSandboxQueueSize || 1;


### PR DESCRIPTION
Our initial fix https://github.com/ember-fastboot/ember-cli-fastboot/pull/894 was done internally using patch-package and this solved our memory usage issue. The workaround https://github.com/ember-fastboot/ember-cli-fastboot/pull/895 we had merged in ending up causing an extremely bad CPU spike in production. Because we traded memory usage for cpu because now we constantly read from disk. We want to turn off source maps as we internally unwrap the source and handle this on error in a different system.
