### PR TITLE
Remove deprecated injections in Ember 4.x

### DIFF
--- a/packages/ember-cli-fastboot/fastboot/initializers/ajax.js
+++ b/packages/ember-cli-fastboot/fastboot/initializers/ajax.js
@@ -1,5 +1,6 @@
 /* globals najax */
 import Ember from 'ember';
+import { gte } from 'ember-compatibility-helpers';
 
 const { get } = Ember;
 
@@ -30,7 +31,10 @@ export default {
 
   initialize: function(application) {
     application.register('ajax:node', nodeAjax, { instantiate: false });
-    application.inject('adapter', '_ajaxRequest', 'ajax:node');
-    application.inject('adapter', 'fastboot', 'service:fastboot');
+
+    if (!gte('4.0.0')) {
+      application.inject('adapter', '_ajaxRequest', 'ajax:node');
+      application.inject('adapter', 'fastboot', 'service:fastboot');
+    }
   }
 };

--- a/packages/ember-cli-fastboot/package.json
+++ b/packages/ember-cli-fastboot/package.json
@@ -39,6 +39,7 @@
     "ember-cli-lodash-subset": "^2.0.1",
     "ember-cli-preprocess-registry": "^3.3.0",
     "ember-cli-version-checker": "^5.1.2",
+    "ember-compatibility-helpers": "^1.2.6",
     "fastboot": "3.3.2",
     "fastboot-express-middleware": "3.3.2",
     "fastboot-transform": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8330,6 +8330,17 @@ ember-compatibility-helpers@^1.2.1:
     fs-extra "^9.1.0"
     semver "^5.4.1"
 
+ember-compatibility-helpers@^1.2.6:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.6.tgz#603579ab2fb14be567ef944da3fc2d355f779cd8"
+  integrity sha512-2UBUa5SAuPg8/kRVaiOfTwlXdeVweal1zdNPibwItrhR0IvPrXpaqwJDlEZnWKEoB+h33V0JIfiWleSG6hGkkA==
+  dependencies:
+    babel-plugin-debug-macros "^0.2.0"
+    ember-cli-version-checker "^5.1.1"
+    find-up "^5.0.0"
+    fs-extra "^9.1.0"
+    semver "^5.4.1"
+
 ember-data@~3.19.0:
   version "3.19.0"
   resolved "https://registry.yarnpkg.com/ember-data/-/ember-data-3.19.0.tgz#f0c75f0143c0f9d9801c486c9c592240b80b5d75"


### PR DESCRIPTION
This is an attempt to fix #869. I don’t have much experience with addon development, but this seemed like a conventional way to check whether `.inject` could still be used.

Thanks for the years of work on this, all!