### PR TITLE
fix: Provide a more meaningful error when whitelist entry is missing

### DIFF
--- a/packages/fastboot/src/fastboot-schema.js
+++ b/packages/fastboot/src/fastboot-schema.js
@@ -189,7 +189,9 @@ function buildWhitelistedRequire(whitelist, distPath, isLegacyWhitelist) {
         }
       } else {
         throw new Error(
-          "Unable to require module '" + moduleName + "' in Fastboot because it was not explicitly allowed in 'fastbootDependencies' in your package.json."
+          "Unable to require module '" +
+            moduleName +
+            "' in Fastboot because it was not explicitly allowed in 'fastbootDependencies' in your package.json."
         );
       }
     }

--- a/packages/fastboot/src/fastboot-schema.js
+++ b/packages/fastboot/src/fastboot-schema.js
@@ -189,7 +189,7 @@ function buildWhitelistedRequire(whitelist, distPath, isLegacyWhitelist) {
         }
       } else {
         throw new Error(
-          "Unable to require module '" + moduleName + "' because it was not in the whitelist."
+          "Unable to require module '" + moduleName + "' in Fastboot because it was not explicitly allowed in 'fastbootDependencies' in your package.json."
         );
       }
     }
@@ -197,9 +197,9 @@ function buildWhitelistedRequire(whitelist, distPath, isLegacyWhitelist) {
     throw new Error(
       "Unable to require module '" +
         moduleName +
-        "' because its package '" +
+        "' in Fastboot because its package '" +
         packageName +
-        "' was not in the whitelist."
+        "' was not explicitly allowed in 'fastbootDependencies' in your package.json."
     );
   };
 }


### PR DESCRIPTION
In emberjs/data#8101 it was noted that the error message provided here did not give enough context for users to understand the issue was due to the Fastboot environment and the existence of the fastbootDependencies allow list. This should help greatly with that.

Ref: https://github.com/emberjs/data/issues/8101#issuecomment-1341675294