### PR TITLE
Remove deprecated implicit-injections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           - ember-lts-3.20
           - ember-lts-3.24
           - ember-lts-3.28
+          - ember-lts-4.4
           - ember-release
           - ember-beta
           - ember-canary

--- a/packages/ember-cli-fastboot/config/ember-try.js
+++ b/packages/ember-cli-fastboot/config/ember-try.js
@@ -44,6 +44,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-4.4',
+        npm: {
+          devDependencies: {
+            'ember-source': '~4.4.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/packages/ember-cli-fastboot/fastboot/initializers/ajax.js
+++ b/packages/ember-cli-fastboot/fastboot/initializers/ajax.js
@@ -30,7 +30,5 @@ export default {
 
   initialize: function(application) {
     application.register('ajax:node', nodeAjax, { instantiate: false });
-    application.inject('adapter', '_ajaxRequest', 'ajax:node');
-    application.inject('adapter', 'fastboot', 'service:fastboot');
   }
 };


### PR DESCRIPTION
Same idea as #900, but also tests against 4.4.

This should fix the Ember 4 deprecations in #869.