### PR TITLE
remove deprecated implicit injection

### DIFF
--- a/packages/fastboot/src/fastboot-info.js
+++ b/packages/fastboot/src/fastboot-info.js
@@ -38,6 +38,5 @@ module.exports = class FastBootInfo {
    */
   register(instance) {
     instance.register('info:-fastboot', this, { instantiate: false });
-    instance.inject('service:fastboot', '_fastbootInfo', 'info:-fastboot');
   }
 };


### PR DESCRIPTION
Already solved here :

```
// ember-cli-fastboot/addon/services/fastboot.js
// this getter/setter pair is to avoid deprecation from [RFC - 680](https://github.com/emberjs/rfcs/pull/680)
  _fastbootInfo: computed({
    get() {
      if (this.__fastbootInfo) {
        return this.__fastbootInfo;
      }

      return getOwner(this).lookup('info:-fastboot');
    },
    set(_key, value) {
      this.__fastbootInfo = value;
      return value;
    }
  }),
```
 but didn't remove the implicit injection:
```
// ember-cli-fastboot/packages/fastboot/src/fastboot-info.js
  instance.inject('service:fastboot', '_fastbootInfo', 'info:-fastboot');
```