### PR TITLE
Drop implicit injection

### DIFF
--- a/packages/fastboot/src/fastboot-info.js
+++ b/packages/fastboot/src/fastboot-info.js
@@ -38,6 +38,5 @@ module.exports = class FastBootInfo {
    */
   register(instance) {
     instance.register('info:-fastboot', this, { instantiate: false });
-    instance.inject('service:fastboot', '_fastbootInfo', 'info:-fastboot');
   }
 };


### PR DESCRIPTION
This is removed at Ember 5, and it wasn't even doing anything because the consuming side of this was already refactored to use owner.lookup instead.