### PR TITLE
fix json stringify in fastboot-config

### DIFF
--- a/packages/ember-cli-fastboot/lib/broccoli/fastboot-config.js
+++ b/packages/ember-cli-fastboot/lib/broccoli/fastboot-config.js
@@ -178,7 +178,7 @@ module.exports = class FastBootConfig extends Plugin {
         config: this.fastbootConfig,
         appName: this.appName,
       }
-    }, null, 2);
+    }, { space: 2 });
   }
 
   normalizeHostWhitelist() {


### PR DESCRIPTION
In https://github.com/ember-fastboot/ember-cli-fastboot/pull/410 we swapped JSON.stringify with https://www.npmjs.com/package/json-stable-stringify but didn't update the args that we passed to it. With a recent release this broke something because passing `null` as the second argument is invalid

This PR fixes that 👍 