### PR TITLE
Add an optional callback to server start

### DIFF
--- a/packages/fastboot-app-server/src/fastboot-app-server.js
+++ b/packages/fastboot-app-server/src/fastboot-app-server.js
@@ -63,7 +63,7 @@ class FastBootAppServer {
     }
   }
 
-  start() {
+  start(callback) {
     if (cluster.isWorker) { return; }
 
     return this.initializeApp()
@@ -72,6 +72,11 @@ class FastBootAppServer {
       .then(() => {
         if (this.initializationError) {
           this.broadcast({ event: 'error', error: this.initializationError.stack });
+        }
+      })
+      .then(() => {
+        if (typeof callback === "function") {
+          callback();
         }
       })
       .catch(err => {


### PR DESCRIPTION
We use Nginx in front of Ember App server. To start Nginx server, it needs to know whether Ember App server has started. The optional callback function added to this PR can be used for this purpose.

Taking example from [Heroku Nginx](https://github.com/heroku/heroku-buildpack-nginx/blob/main/proxy.md), a callback function can be like the following:

```javascript
server.start(function () {
  fs.openSync('/tmp/app-initialized', 'w');
});
```