### PR TITLE
mark fastboot-test-scenarios as private

### DIFF
--- a/test-packages/test-scenarios/package.json
+++ b/test-packages/test-scenarios/package.json
@@ -1,5 +1,6 @@
 {
   "name": "fastboot-test-scenarios",
+  "private": true,
   "scripts": {
     "test": "qunit *-test.mjs",
     "test:list": "scenario-tester-esm list --files=*-test.mjs",


### PR DESCRIPTION
this package shouldn't be released when release-plan is doing its work, so we need to set it as private