### PR TITLE
remove ember-source peerDependency from ember-cli-fastboot

### DIFF
--- a/packages/ember-cli-fastboot/package.json
+++ b/packages/ember-cli-fastboot/package.json
@@ -101,9 +101,6 @@
     "stylelint-config-standard": "^36.0.1",
     "webpack": "^5.106.0"
   },
-  "peerDependencies": {
-    "ember-source": ">=3.16"
-  },
   "engines": {
     "node": ">= 20.19"
   },


### PR DESCRIPTION
it's not recommended to have ember-source as a peer dependency for anything, this is not an effective way to manage supported versions