### PR TITLE
Fix ember v6 deprecate-import-view-utils-from-ember deprecation

### DIFF
--- a/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
+++ b/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
@@ -3,24 +3,37 @@
   if (typeof FastBoot === 'undefined') {
     var current = document.getElementById('fastboot-body-start');
 
-    var _Ember = require.has('ember') ? require('ember').default : window.Ember;
-    var _ViewUtils = require.has('@ember/-internals/views')
-      ? require('@ember/-internals/views')
-      : _Ember.ViewUtils;
+    if (!current) {
+      return;
+    }
 
-    if (current && !_Ember) {
+    var isSerializationFirstNode;
+    var ApplicationInstance;
+
+    if (require.has('@ember/-internals/glimmer') && require.has('@ember/application/instance')) {
+      isSerializationFirstNode = require('@ember/-internals/glimmer').isSerializationFirstNode;
+      ApplicationInstance = require('@ember/application/instance').default;
+    } else if (require.has('ember')) {
+      var _Ember = require('ember').default;
+      isSerializationFirstNode = _Ember.ViewUtils.isSerializationFirstNode;
+      ApplicationInstance = _Ember.ApplicationInstance;
+    } else if (window.Ember) {
+      isSerializationFirstNode = window.Ember.ViewUtils.isSerializationFirstNode;
+      ApplicationInstance = window.Ember.ApplicationInstance;
+    }
+
+    if (!isSerializationFirstNode || !ApplicationInstance) {
       console.error(`Experimental render mode rehydrate isn't working because it couldn't find Ember via AMD or global.
 See https://github.com/ember-fastboot/ember-cli-fastboot/issues/938 for the current state of the fix.`);
       return;
     }
 
     if (
-      current &&
-      typeof _ViewUtils.isSerializationFirstNode === 'function' &&
-      _ViewUtils.isSerializationFirstNode(current.nextSibling)
+      typeof isSerializationFirstNode === 'function' &&
+      isSerializationFirstNode(current.nextSibling)
     ) {
-      _Ember.ApplicationInstance.reopen({
-        _bootSync: function (options) {
+      ApplicationInstance.reopen({
+        _bootSync: function(options) {
           if (options === undefined) {
             options = {
               _renderMode: 'rehydrate',

--- a/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
+++ b/packages/ember-cli-fastboot/vendor/experimental-render-mode-rehydrate.js
@@ -4,6 +4,9 @@
     var current = document.getElementById('fastboot-body-start');
 
     var _Ember = require.has('ember') ? require('ember').default : window.Ember;
+    var _ViewUtils = require.has('@ember/-internals/views')
+      ? require('@ember/-internals/views')
+      : _Ember.ViewUtils;
 
     if (current && !_Ember) {
       console.error(`Experimental render mode rehydrate isn't working because it couldn't find Ember via AMD or global.
@@ -13,8 +16,8 @@ See https://github.com/ember-fastboot/ember-cli-fastboot/issues/938 for the curr
 
     if (
       current &&
-      typeof _Ember.ViewUtils.isSerializationFirstNode === 'function' &&
-      _Ember.ViewUtils.isSerializationFirstNode(current.nextSibling)
+      typeof _ViewUtils.isSerializationFirstNode === 'function' &&
+      _ViewUtils.isSerializationFirstNode(current.nextSibling)
     ) {
       _Ember.ApplicationInstance.reopen({
         _bootSync: function (options) {


### PR DESCRIPTION
This has been extracted from https://github.com/ember-fastboot/ember-cli-fastboot/pull/955